### PR TITLE
feat: add search and history functionality with filtering and sorting…

### DIFF
--- a/src/domain/archive.ts
+++ b/src/domain/archive.ts
@@ -88,6 +88,8 @@ export type CreateItemInput = {
   notes?: string[];
   tags?: string[];
   collections?: string[];
+  createdAt?: string;
+  updatedAt?: string;
   attributes?: Record<string, AttributeValue>;
   externalIds?: Record<string, string>;
   imageUrl?: string;
@@ -114,6 +116,8 @@ export const createItem = (input: CreateItemInput): Item => {
     notes: z.array(z.string()).default([]),
     tags: z.array(z.string()).default([]),
     collections: z.array(z.string()).default([]),
+    createdAt: z.string().datetime().optional(),
+    updatedAt: z.string().datetime().optional(),
     attributes: z.record(z.string(), AttributeValueSchema).default({}),
     externalIds: z.record(z.string(), z.string()).default({}),
     imageUrl: z.string().url().optional(),
@@ -137,8 +141,8 @@ export const createItem = (input: CreateItemInput): Item => {
     notes: parsed.notes,
     tags: parsed.tags,
     collections: parsed.collections,
-    createdAt: now,
-    updatedAt: now,
+    createdAt: parsed.createdAt ?? now,
+    updatedAt: parsed.updatedAt ?? now,
     attributes: parsed.attributes,
     externalIds: parsed.externalIds,
     imageUrl: parsed.imageUrl,

--- a/src/domain/search.ts
+++ b/src/domain/search.ts
@@ -1,0 +1,112 @@
+import type { HistoryEntry, Item, ItemStatus } from './archive.js';
+
+export type SearchFilter = {
+  status?: ItemStatus[];
+  category?: string[];
+  collection?: string[];
+  tag?: string[];
+  query?: string;
+  ratingMin?: number;
+  ratingMax?: number;
+};
+
+export type HistoryAction = HistoryEntry['action'];
+
+export type HistoryEntryInput = {
+  id?: string;
+  itemId: string;
+  action: HistoryAction;
+  timestamp?: string;
+  summary: string;
+};
+
+export const createHistoryEntry = (input: HistoryEntryInput): HistoryEntry => ({
+  id: input.id ?? crypto.randomUUID(),
+  itemId: input.itemId,
+  action: input.action,
+  timestamp: input.timestamp ?? new Date().toISOString(),
+  summary: input.summary,
+});
+
+export const searchItems = (items: Item[], query: string): Item[] => {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return items;
+  }
+
+  return items.filter((item) => {
+    const haystack = [
+      item.title,
+      item.category,
+      item.type,
+      item.description ?? '',
+      item.notes.join(' '),
+      item.tags.join(' '),
+      item.collections.join(' '),
+      Object.values(item.attributes).join(' '),
+    ].join(' ').toLowerCase();
+
+    return haystack.includes(normalized);
+  });
+};
+
+export const filterItems = (items: Item[], filters: SearchFilter): Item[] => {
+  return items.filter((item) => {
+    if (filters.status && filters.status.length > 0 && !filters.status.includes(item.status)) {
+      return false;
+    }
+
+    if (filters.category && filters.category.length > 0 && !filters.category.includes(item.category)) {
+      return false;
+    }
+
+    if (filters.collection && filters.collection.length > 0) {
+      const matchesCollection = item.collections.some((collection) => filters.collection!.includes(collection));
+      if (!matchesCollection) {
+        return false;
+      }
+    }
+
+    if (filters.tag && filters.tag.length > 0) {
+      const matchesTag = item.tags.some((tag) => filters.tag!.includes(tag));
+      if (!matchesTag) {
+        return false;
+      }
+    }
+
+    if (typeof filters.ratingMin === 'number' && (item.rating ?? 0) < filters.ratingMin) {
+      return false;
+    }
+
+    if (typeof filters.ratingMax === 'number' && (item.rating ?? 0) > filters.ratingMax) {
+      return false;
+    }
+
+    if (filters.query) {
+      const result = searchItems([item], filters.query);
+      if (result.length === 0) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+};
+
+export const sortItems = <T extends Item>(items: T[], field: 'updatedAt' | 'createdAt' | 'title'): T[] => {
+  const sorted = [...items];
+
+  sorted.sort((left, right) => {
+    if (field === 'title') {
+      return left.title.localeCompare(right.title);
+    }
+
+    return new Date(right[field]).getTime() - new Date(left[field]).getTime();
+  });
+
+  return sorted;
+};
+
+export const getHistoryTimeline = (history: HistoryEntry[]): HistoryEntry[] => {
+  return [...history].sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime());
+};

--- a/tests/search-history.test.ts
+++ b/tests/search-history.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { createItem } from '../src/domain/archive.js';
+import {
+  createHistoryEntry,
+  filterItems,
+  getHistoryTimeline,
+  searchItems,
+  sortItems,
+} from '../src/domain/search.js';
+
+describe('local search and history', () => {
+  const books = [
+    createItem({
+      title: 'Dune',
+      category: 'book',
+      status: 'in_progress',
+      progress: { current: 184, target: 688, unit: 'pages' },
+      rating: 5,
+      notes: ['Strong worldbuilding'],
+      tags: ['classic', 'sci-fi'],
+      collections: ['favorites'],
+      createdAt: '2024-01-01T10:00:00.000Z',
+      updatedAt: '2024-01-01T10:00:00.000Z',
+      attributes: { author: 'Frank Herbert' },
+    }),
+    createItem({
+      title: 'The Left Hand of Darkness',
+      category: 'book',
+      status: 'completed',
+      progress: { current: 1, target: 1, unit: 'book' },
+      rating: 4,
+      notes: ['Very thoughtful'],
+      tags: ['classic'],
+      collections: ['read-later'],
+      createdAt: '2024-01-02T10:00:00.000Z',
+      updatedAt: '2024-01-02T10:00:00.000Z',
+      attributes: { author: 'Ursula K. Le Guin' },
+    }),
+    createItem({
+      title: 'Arrival',
+      category: 'film',
+      status: 'planned',
+      progress: { current: 0, target: 1, unit: 'film' },
+      rating: 3,
+      notes: ['Need to watch'],
+      tags: ['thoughtful'],
+      collections: ['watchlist'],
+      createdAt: '2024-01-03T10:00:00.000Z',
+      updatedAt: '2024-01-03T10:00:00.000Z',
+      attributes: { director: 'Denis Villeneuve' },
+    }),
+  ];
+
+  it('searches across title, tags, and notes', () => {
+    const result = searchItems(books, 'worldbuilding');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Dune');
+  });
+
+  it('filters by status and collection', () => {
+    const result = filterItems(books, {
+      status: ['completed'],
+      collection: ['favorites'],
+    });
+
+    expect(result).toHaveLength(0);
+
+    const completedBooks = filterItems(books, {
+      status: ['completed'],
+      collection: ['read-later'],
+    });
+
+    expect(completedBooks).toHaveLength(1);
+    expect(completedBooks[0].title).toBe('The Left Hand of Darkness');
+  });
+
+  it('sorts items by updatedAt descending', () => {
+    const sorted = sortItems(books, 'updatedAt');
+
+    expect(sorted[0].title).toBe('Arrival');
+  });
+
+  it('builds a history timeline from actions across items', () => {
+    const timeline = getHistoryTimeline([
+      createHistoryEntry({
+        itemId: books[0].id,
+        action: 'created',
+        summary: 'Added Dune',
+        timestamp: '2024-01-01T10:00:00.000Z',
+      }),
+      createHistoryEntry({
+        itemId: books[1].id,
+        action: 'completed',
+        summary: 'Finished The Left Hand of Darkness',
+        timestamp: '2024-01-02T10:00:00.000Z',
+      }),
+    ]);
+
+    expect(timeline).toHaveLength(2);
+    expect(timeline[0].action).toBe('completed');
+    expect(timeline[1].action).toBe('created');
+  });
+});


### PR DESCRIPTION
## What

Close #6 

## Why

Users need to find and review their personal items without relying on a central backend or network service. Without local search and history browsing, the archive becomes difficult to use as it grows, especially for long-term personal tracking.

This preserves the project’s local-first promise and keeps discovery and review fully offline.

## How

The implementation follows the project’s architecture and keeps business logic in the domain layer, not in storage or UI code.

The approach was:

- keep all logic pure and testable
- work against the existing generic item model
- add reusable query functions rather than UI-bound code
- model history as a lightweight timeline of actions, sorted by timestamp
- avoid introducing any backend or provider dependency
- This keeps the feature extensible and consistent with the generic tracking model.

## Verification

I verified this with the project test suite and TypeScript compile check.

## Data impact

No schema migration, persistence, backup, or sync logic was introduced.

This change is limited to local domain querying and history composition. It does not alter stored/archive formats or migration behavior.

If invalid or empty data is provided, the behavior is intentionally safe:

- empty queries return the full list
- filters with no matches return an empty list
- history timeline is built from the provided entries and sorted deterministically without crashing

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed
- [x] Accessibility considered for UI/interaction changes
- [x] No unrelated refactors bundled into this PR
