### PR TITLE
feat(storage): add browser-local archive persistence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,7 @@ Domain
 Repository Interfaces
 |
 +-- Local SQLite
++-- Browser IndexedDB archive store (web)
 +-- Backup / Export
 +-- Catalog Providers
 +-- Optional Network Adapter
@@ -87,6 +88,8 @@ Examples:
 React components and application screens.
 
 UI components must not access SQLite directly.
+
+The web adapter follows the same rule: UI components must not access IndexedDB directly. It stores the complete archive behind an application boundary; IndexedDB is not the backup format.
 
 ## Generic item model
 

--- a/docs/rfcs/0001-browser-local-archive-persistence.md
+++ b/docs/rfcs/0001-browser-local-archive-persistence.md
@@ -1,0 +1,64 @@
+# RFC: Browser-local archive persistence
+
+## Status
+
+Draft
+
+## Summary
+
+The web application will store one complete `ArchiveSnapshot` in IndexedDB. IndexedDB is an infrastructure implementation detail behind a browser archive store, not the archive format or a substitute for export and restore.
+
+## User problem
+
+Users need their personal archive to survive reopening the browser without an account, network connection, or provider dependency.
+
+## Goals
+
+- Persist the complete archive locally in the web application.
+- Validate snapshots at the persistence boundary.
+- Migrate stored snapshots before exposing them to the application.
+- Keep browser storage aligned with the portable archive format.
+
+## Non-goals
+
+- Cloud sync, accounts, telemetry, or remote storage.
+- Treating IndexedDB as a user backup.
+- Splitting the archive into browser-specific stores or duplicating domain query logic.
+
+## Proposed design
+
+`BrowserArchiveStore` owns all IndexedDB access. It writes one record named `current` containing the complete snapshot. On load, it rejects future schema versions, runs the existing migration pipeline, and validates the result before returning it. Invalid data never overwrites the last valid record.
+
+## Data model impact
+
+The portable `ArchiveSnapshot` remains the data contract. The IndexedDB record wraps it with an implementation-only key.
+
+## Privacy impact
+
+Data remains in the browser on the user device. The adapter makes no network requests and collects no telemetry.
+
+## Offline impact
+
+Persistence works without a network connection. Loading the application itself offline is addressed separately.
+
+## Portability impact
+
+Export and restore continue to operate on `ArchiveSnapshot`, not the IndexedDB record. Users are not locked into IndexedDB.
+
+## Migration strategy
+
+Older snapshots are migrated through the domain migration pipeline. Snapshots from a newer schema version are rejected without modifying stored data.
+
+## Alternatives considered
+
+- Local storage: less suitable for a complete archive and has weaker transactional semantics.
+- Multiple object stores: adds browser-specific schema and duplicated query logic before it is needed.
+- IndexedDB as backup: does not provide a portable, user-controlled recovery file.
+
+## Risks
+
+Browser storage can be cleared by the user or browser. Export and restore remain necessary for data durability.
+
+## Open questions
+
+- Which application use-case interface should own archive mutations before the web shell is connected in issue #44?

--- a/src/storage/browser-archive-store.ts
+++ b/src/storage/browser-archive-store.ts
@@ -1,0 +1,127 @@
+import {
+  CURRENT_SCHEMA_VERSION,
+  migrateArchiveSnapshot,
+  parseArchiveSnapshot,
+  type ArchiveSnapshot,
+} from '../domain/archive.js';
+
+export const BROWSER_ARCHIVE_DATABASE_NAME = 'open-personal-tracking';
+export const BROWSER_ARCHIVE_STORE_NAME = 'archive';
+export const BROWSER_ARCHIVE_RECORD_KEY = 'current';
+
+type BrowserArchiveRecord = {
+  key: typeof BROWSER_ARCHIVE_RECORD_KEY;
+  snapshot: unknown;
+};
+
+const requestResult = <T>(request: IDBRequest<T>): Promise<T> => new Promise((resolve, reject) => {
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+});
+
+const transactionComplete = (transaction: IDBTransaction): Promise<void> => new Promise((resolve, reject) => {
+  transaction.oncomplete = () => resolve();
+  transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction was aborted'));
+  transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+});
+
+const openDatabase = (indexedDB: IDBFactory): Promise<IDBDatabase> => new Promise((resolve, reject) => {
+  const request = indexedDB.open(BROWSER_ARCHIVE_DATABASE_NAME, 1);
+
+  request.onupgradeneeded = () => {
+    const database = request.result;
+    if (!database.objectStoreNames.contains(BROWSER_ARCHIVE_STORE_NAME)) {
+      database.createObjectStore(BROWSER_ARCHIVE_STORE_NAME, { keyPath: 'key' });
+    }
+  };
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error ?? new Error('Could not open browser archive storage'));
+  request.onblocked = () => reject(new Error('Browser archive storage upgrade is blocked by another open tab'));
+});
+
+const migrateStoredSnapshot = (value: unknown): ArchiveSnapshot => {
+  if (value && typeof value === 'object') {
+    const schemaVersion = (value as Record<string, unknown>).schemaVersion;
+    if (
+      typeof schemaVersion === 'number'
+      && Number.isInteger(schemaVersion)
+      && schemaVersion > CURRENT_SCHEMA_VERSION
+    ) {
+      throw new Error(`Unsupported archive schema version: ${schemaVersion}`);
+    }
+  }
+
+  return parseArchiveSnapshot(migrateArchiveSnapshot(value));
+};
+
+const storedSnapshot = (record: unknown): unknown => {
+  if (!record || typeof record !== 'object' || !('snapshot' in record) || record.snapshot === undefined) {
+    throw new Error('Stored browser archive record is malformed');
+  }
+
+  return record.snapshot;
+};
+
+/**
+ * Browser infrastructure for the complete local archive. It intentionally stores
+ * one snapshot so the persistence boundary stays aligned with export and restore.
+ */
+export class BrowserArchiveStore {
+  private readonly indexedDB: IDBFactory;
+
+  constructor(indexedDBFactory: IDBFactory | undefined = globalThis.indexedDB) {
+    if (!indexedDBFactory) {
+      throw new Error('IndexedDB is not available in this browser');
+    }
+
+    this.indexedDB = indexedDBFactory;
+  }
+
+  async load(): Promise<ArchiveSnapshot | null> {
+    const database = await openDatabase(this.indexedDB);
+
+    try {
+      const transaction = database.transaction(BROWSER_ARCHIVE_STORE_NAME, 'readonly');
+      const completed = transactionComplete(transaction);
+      const request = transaction.objectStore(BROWSER_ARCHIVE_STORE_NAME).get(BROWSER_ARCHIVE_RECORD_KEY);
+      const record = await requestResult(request) as BrowserArchiveRecord | undefined;
+      await completed;
+
+      return record ? migrateStoredSnapshot(storedSnapshot(record)) : null;
+    } finally {
+      database.close();
+    }
+  }
+
+  async save(snapshot: ArchiveSnapshot): Promise<void> {
+    const normalized = parseArchiveSnapshot(snapshot);
+    const database = await openDatabase(this.indexedDB);
+
+    try {
+      const transaction = database.transaction(BROWSER_ARCHIVE_STORE_NAME, 'readwrite');
+      const completed = transactionComplete(transaction);
+      const request = transaction.objectStore(BROWSER_ARCHIVE_STORE_NAME).put({
+        key: BROWSER_ARCHIVE_RECORD_KEY,
+        snapshot: normalized,
+      } satisfies BrowserArchiveRecord);
+      await requestResult(request);
+      await completed;
+    } finally {
+      database.close();
+    }
+  }
+
+  async clear(): Promise<void> {
+    const database = await openDatabase(this.indexedDB);
+
+    try {
+      const transaction = database.transaction(BROWSER_ARCHIVE_STORE_NAME, 'readwrite');
+      const completed = transactionComplete(transaction);
+      const request = transaction.objectStore(BROWSER_ARCHIVE_STORE_NAME).delete(BROWSER_ARCHIVE_RECORD_KEY);
+      await requestResult(request);
+      await completed;
+    } finally {
+      database.close();
+    }
+  }
+}

--- a/tests/browser-archive-store.test.ts
+++ b/tests/browser-archive-store.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import { createEmptyArchive, createItem } from '../src/domain/archive.js';
+import {
+  BROWSER_ARCHIVE_RECORD_KEY,
+  BROWSER_ARCHIVE_STORE_NAME,
+  BrowserArchiveStore,
+} from '../src/storage/browser-archive-store.js';
+
+class TestRequest<T> {
+  result!: T;
+  error: DOMException | null = null;
+  onsuccess: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  succeed(result: T): void {
+    this.result = result;
+    queueMicrotask(() => this.onsuccess?.(new Event('success')));
+  }
+}
+
+class TestTransaction {
+  error: DOMException | null = null;
+  oncomplete: ((event: Event) => void) | null = null;
+  onabort: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(private readonly records: Map<string, unknown>) {}
+
+  objectStore(): { get: (key: string) => TestRequest<unknown>; put: (value: { key: string }) => TestRequest<IDBValidKey>; delete: (key: string) => TestRequest<undefined> } {
+    return {
+      get: (key) => this.run(() => this.records.get(key)),
+      put: (value) => this.run(() => {
+        this.records.set(value.key, structuredClone(value));
+        return value.key;
+      }),
+      delete: (key) => this.run(() => {
+        this.records.delete(key);
+        return undefined;
+      }),
+    };
+  }
+
+  private run<T>(operation: () => T): TestRequest<T> {
+    const request = new TestRequest<T>();
+    queueMicrotask(() => {
+      request.succeed(operation());
+      queueMicrotask(() => this.oncomplete?.(new Event('complete')));
+    });
+    return request;
+  }
+}
+
+class TestDatabase {
+  readonly objectStoreNames: { contains: (name: string) => boolean };
+  private hasArchiveStore = false;
+  private readonly records = new Map<string, unknown>();
+
+  constructor() {
+    this.objectStoreNames = { contains: (name) => name === BROWSER_ARCHIVE_STORE_NAME && this.hasArchiveStore };
+  }
+
+  createObjectStore(): void {
+    this.hasArchiveStore = true;
+  }
+
+  transaction(): TestTransaction {
+    return new TestTransaction(this.records);
+  }
+
+  close(): void {}
+
+  seed(value: unknown): void {
+    this.records.set(BROWSER_ARCHIVE_RECORD_KEY, { key: BROWSER_ARCHIVE_RECORD_KEY, snapshot: value });
+  }
+
+  rawValue(): unknown {
+    return this.records.get(BROWSER_ARCHIVE_RECORD_KEY);
+  }
+}
+
+class TestIndexedDbFactory {
+  private readonly database = new TestDatabase();
+  private opened = false;
+
+  open(): TestRequest<TestDatabase> & { onupgradeneeded: ((event: IDBVersionChangeEvent) => void) | null; onblocked: ((event: Event) => void) | null } {
+    const request = new TestRequest<TestDatabase>() as TestRequest<TestDatabase> & {
+      onupgradeneeded: ((event: IDBVersionChangeEvent) => void) | null;
+      onblocked: ((event: Event) => void) | null;
+    };
+    request.onupgradeneeded = null;
+    request.onblocked = null;
+    request.result = this.database;
+
+    queueMicrotask(() => {
+      if (!this.opened) {
+        this.opened = true;
+        request.onupgradeneeded?.(new Event('upgradeneeded') as IDBVersionChangeEvent);
+      }
+      request.succeed(this.database);
+    });
+
+    return request;
+  }
+
+  seed(value: unknown): void {
+    this.database.seed(value);
+  }
+
+  rawValue(): unknown {
+    return this.database.rawValue();
+  }
+}
+
+const createStore = (factory: TestIndexedDbFactory): BrowserArchiveStore =>
+  new BrowserArchiveStore(factory as unknown as IDBFactory);
+
+describe('browser archive storage', () => {
+  it('persists the complete archive across store instances', async () => {
+    const factory = new TestIndexedDbFactory();
+    const archive = createEmptyArchive();
+    archive.preferences = { displayName: 'Ludo', locale: 'it', activities: ['books'], favoriteGenres: ['science fiction'], onboardingCompleted: true };
+    archive.items.push(createItem({
+      title: 'Dune',
+      category: 'book',
+      progress: { current: 184, target: 688, unit: 'pages' },
+      notes: ['Strong worldbuilding'],
+      tags: ['classic'],
+      collections: ['favorites'],
+    }));
+    archive.collections.push({
+      id: 'favorites', name: 'Favorites', createdAt: archive.exportedAt, updatedAt: archive.exportedAt, itemIds: [archive.items[0].id],
+    });
+    archive.history.push({ id: 'created-dune', itemId: archive.items[0].id, action: 'created', timestamp: archive.exportedAt, summary: 'Added Dune' });
+
+    await createStore(factory).save(archive);
+    const restored = await createStore(factory).load();
+
+    expect(restored).toEqual(archive);
+  });
+
+  it('migrates legacy snapshots before exposing them', async () => {
+    const factory = new TestIndexedDbFactory();
+    factory.seed({
+      title: 'ignored at archive level',
+      items: [{ title: 'Dune', category: 'book', progress: { current: 184, unit: 'pages' } }],
+    });
+
+    const restored = await createStore(factory).load();
+
+    expect(restored?.schemaVersion).toBe(1);
+    expect(restored?.items[0]).toMatchObject({ title: 'Dune', category: 'book', progress: { current: 184, unit: 'pages' } });
+  });
+
+  it('does not replace a valid archive when a new snapshot is invalid', async () => {
+    const factory = new TestIndexedDbFactory();
+    const store = createStore(factory);
+    const archive = createEmptyArchive();
+    archive.items.push(createItem({ title: 'Dune', category: 'book', progress: { current: 0, unit: 'pages' } }));
+    await store.save(archive);
+
+    await expect(store.save({ ...archive, items: [{ title: 'Invalid item' }] } as unknown as typeof archive)).rejects.toThrow();
+
+    await expect(store.load()).resolves.toEqual(archive);
+  });
+
+  it('rejects an unsupported stored schema without modifying it', async () => {
+    const factory = new TestIndexedDbFactory();
+    const unsupported = { schemaVersion: 2, exportedAt: new Date().toISOString(), items: [], collections: [], history: [] };
+    factory.seed(unsupported);
+
+    await expect(createStore(factory).load()).rejects.toThrow('Unsupported archive schema version: 2');
+    expect(factory.rawValue()).toEqual({ key: BROWSER_ARCHIVE_RECORD_KEY, snapshot: unsupported });
+  });
+
+  it('clears the stored archive', async () => {
+    const factory = new TestIndexedDbFactory();
+    const store = createStore(factory);
+    await store.save(createEmptyArchive());
+
+    await store.clear();
+
+    await expect(store.load()).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a browser-local archive persistence adapter backed by IndexedDB.

Also adds automated coverage for browser archive storage, a draft RFC for the persistence contract, and architecture documentation for the web adapter.

Close #43 

## Why

The web application needs a durable, local, account-free storage boundary for the complete `ArchiveSnapshot`. This is foundational work for replacing demo state with real persisted data in #44.

## How

- Store one complete `ArchiveSnapshot` in a single IndexedDB record.
- Keep IndexedDB behind `BrowserArchiveStore`; UI components do not access it directly.
- Validate snapshots before saving.
- Migrate and validate stored snapshots before exposing them.
- Reject unsupported future schema versions without changing stored data.
- Keep IndexedDB separate from backup/export and restore concerns.

## Verification

- Added tests for persistence across store instances, legacy migration, invalid-save protection, unsupported schema handling, and clearing storage.
- Ran `npm test` — 18 tests passed.
- Ran `npm run build` — passed.

## Data impact

Yes. This adds browser-local persistence for the complete archive.

Failure behavior:

- An invalid snapshot is rejected before any write begins, so the last valid stored archive remains unchanged.
- A malformed record or unsupported future schema version is rejected on load and is not overwritten.
- Stored snapshots are migrated and validated before use.
- IndexedDB is not treated as a backup mechanism; export/restore remain separate work.
- This PR does not add import, export, synchronization, or UI-driven deletion flows.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed
- [x] Accessibility considered for UI/interaction changes — no UI or interaction changes in this PR
- [x] No unrelated refactors bundled into this PR