### PR TITLE
fix(app): improve item selection handling and update CSS for content …

### DIFF
--- a/web/app/app-shell/page.tsx
+++ b/web/app/app-shell/page.tsx
@@ -423,9 +423,7 @@ export default function AppShellPage() {
 
   useEffect(() => {
     setSelectedId((current) =>
-      items.some((item) => item.id === current)
-        ? current
-        : (items[0]?.id ?? null),
+      items.some((item) => item.id === current) ? current : null,
     );
   }, [items]);
 
@@ -826,7 +824,10 @@ export default function AppShellPage() {
         )}
 
         {isLibrary ? (
-          <div className="content" id="panelLibrary">
+          <div
+            className={`content ${hasSelectedItem ? '' : 'content--without-details'}`}
+            id="panelLibrary"
+          >
             <section
               className="library-panel"
               aria-labelledby="library-panel-title"
@@ -1057,7 +1058,11 @@ export default function AppShellPage() {
               )}
             </section>
 
-            <aside className="detail-panel" aria-label="Selected item details">
+            <aside
+              className="detail-panel"
+              aria-label="Selected item details"
+              hidden={!hasSelectedItem}
+            >
               <div className="detail-header">
                 <strong>Details</strong>
                 <div className="detail-actions">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -931,6 +931,10 @@ section.copy .muted {
   flex: 1;
 }
 
+.content--without-details {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .library-panel,
 .detail-panel {
   background: var(--surface);


### PR DESCRIPTION
## What

Close #56

Hide the Details panel when no library item is selected.

## Why

The app automatically selected the first archived item after loading. As a result, the Details panel was visible even when the user had not explicitly selected anything.

This made the selection state unclear and occupied library space with unrelated details.

## How

- Preserve the current selection only while its item still exists; otherwise reset it to `null` instead of selecting the first item automatically.
- Hide the Details panel when there is no selected domain item.
- Apply a single-column Library layout while the Details panel is hidden.

## Verification

- Husky pre-commit check: Prettier and web ESLint passed for the staged file.
- `npm run format:check`
- `npm run lint --prefix web`
- `npm run build --prefix web`
- `git diff --check`

## Data impact

No.

This change only affects presentation and selection state in the app shell. It does not change persistence, migrations, backup, import, export, deletion, or synchronization behavior.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [ ] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed (not applicable)
- [x] Accessibility considered for UI/interaction changes
- [x] No unrelated refactors bundled into this PR