### PR TITLE
feat(backup): implement local backup export and restore functionality

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,5 +7,11 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  ignorePatterns: ['dist/', 'coverage/', 'web/'],
+  ignorePatterns: [
+    'dist/',
+    'coverage/',
+    'playwright-report/',
+    'test-results/',
+    'web/',
+  ],
 };

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -58,3 +58,9 @@ jobs:
 
       - name: Build web application
         run: npm run build --prefix web
+
+      - name: Install Chromium for end-to-end tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Test backup and restore flow in Chromium
+        run: npm run test:e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.0.0/
 
 ### Added
 
+- Complete browser-local JSON backup export and restore, with validation and migration before local data is replaced.
 - Automated linting and formatting checks for contributions and pull requests, with staged-file checks before each commit.
 - Series tracking in the app shell, with season and episode views.
 - Episode-level completion: a season is complete only when all of its episodes are marked watched.

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -20,24 +20,22 @@ open-personal-tracking
 
 or use another permanent neutral identifier.
 
-## Envelope
+## Current backup shape
 
-Initial conceptual structure:
+Backups currently serialize the complete, versioned `ArchiveSnapshot` directly:
 
 ```json
 {
-	"format": "open-personal-tracking",
-	"formatVersion": 1,
-	"exportedAt": "2026-08-27T00:00:00Z",
-	"data": {
-		"items": [],
-		"trackingEntries": [],
-		"collections": [],
-		"tags": [],
-		"history": []
-	}
+	"schemaVersion": 1,
+	"exportedAt": "2026-08-27T00:00:00.000Z",
+	"items": [],
+	"collections": [],
+	"history": [],
+	"preferences": {}
 }
 ```
+
+Restore rejects backups from a future schema version. It migrates supported legacy snapshots and validates the result before replacing local data.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ The repository currently contains two local development surfaces:
 npm install
 npm run build
 npm test
+npm run test:e2e
 ```
+
+The end-to-end suite starts the web app and runs the backup-and-restore
+recovery flow in Chromium. Install its browser binary once with
+`npx playwright install chromium` before running it locally.
 
 ### Web app
 
@@ -144,7 +149,7 @@ Everyone is welcome to join, whether you want to triage, pick up an issue, or ju
 
 Early-stage.
 
-The web app currently provides a local UI preview for the main tracking flows. The durable storage, backup/restore flow, and the optional network layer remain under active development; see the [Product Requirements](docs/PRODUCT_REQUIREMENTS.md) and [Roadmap](ROADMAP.md) for the planned scope.
+The web app provides browser-local tracking, complete JSON backup export, and validated JSON restore. The optional network layer remains under active development; see the [Product Requirements](docs/PRODUCT_REQUIREMENTS.md) and [Roadmap](ROADMAP.md) for the planned scope.
 
 The first milestone is intentionally small: prove that a user can create data locally, close the app, reopen it, export everything, delete the local state, restore the backup, and recover the same information.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,6 +59,10 @@ Use for:
 
 Use for critical user workflows.
 
+Run the browser suite with `npm run test:e2e`. It uses Chromium and starts the
+web application automatically; install the browser locally with
+`npx playwright install chromium`.
+
 Mandatory foundational scenario:
 
 1. Create an item.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,6 +91,8 @@ UI components must not access SQLite directly.
 
 The web adapter follows the same rule: UI components must not access IndexedDB directly. It stores the complete archive behind an application boundary; IndexedDB is not the backup format.
 
+Backup export and restore use the same application boundary. The UI downloads or reads a local JSON file, while `ArchiveApplication` serializes or prepares a complete `ArchiveSnapshot`. A restore is parsed, migrated, and validated before the persistence adapter receives it; invalid and unsupported backups leave the stored archive untouched.
+
 ## Generic item model
 
 Avoid tables and domain logic tied to a single media category.

--- a/docs/rfcs/0002-local-backup-restore.md
+++ b/docs/rfcs/0002-local-backup-restore.md
@@ -1,0 +1,25 @@
+# RFC 0002: Local backup export and restore
+
+## Summary
+
+The application exports the complete `ArchiveSnapshot` as a user-downloaded JSON file and restores it from a user-selected local JSON file. No account, network request, or provider is involved.
+
+## Decision
+
+The backup format is the portable `ArchiveSnapshot`, not the IndexedDB record. Export validates the current snapshot before serialization. Restore parses the file, rejects a future `schemaVersion`, runs supported migrations, validates the resulting snapshot, and only then writes it through the archive persistence boundary.
+
+## Safety rules
+
+- A malformed, invalid, or unsupported backup must not replace the current archive.
+- Restore requires explicit user confirmation because it replaces the current local archive.
+- The restored snapshot contains items, progress, ratings, notes, tags, collections, history, and preferences together.
+- Backup files stay local to the user unless the user chooses to move them.
+
+## Compatibility
+
+`schemaVersion` identifies the archive format. The application migrates supported older snapshots and rejects newer snapshots rather than coercing or discarding them. Breaking format changes require an additional migration, automated coverage, and a changelog entry.
+
+## Alternatives considered
+
+- Treat IndexedDB as the backup: it is browser-specific and does not give users a portable recovery file.
+- Offer an export preview or disabled import control: these do not provide recovery after local data is removed.

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const APP_PATH = '/app-shell';
+const ARCHIVE_DATABASE_NAME = 'open-personal-tracking';
+const ONBOARDING_STORAGE_KEY = 'open-personal-tracking.preferences.v1';
+const TITLE = 'Backup recovery fixture';
+
+const itemInList = (page: Page, title: string) =>
+  page
+    .getByLabel('Item list')
+    .getByRole('heading', { name: title, exact: true });
+
+const completeOnboarding = async (page: Page): Promise<void> => {
+  await page.addInitScript(
+    ({ key }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ onboardingCompleted: true }),
+      );
+    },
+    { key: ONBOARDING_STORAGE_KEY },
+  );
+};
+
+const addItem = async (page: Page, title = TITLE): Promise<void> => {
+  await page.getByRole('button', { name: 'New item' }).click();
+  const drawer = page.getByRole('dialog', { name: 'New item' });
+
+  await drawer.getByLabel('Title').fill(title);
+  await drawer.getByLabel('Description').fill('A local recovery fixture.');
+  await drawer.getByLabel('Rating').fill('4.5');
+  await drawer.getByLabel('Tags').fill('science fiction, favourite');
+  await drawer.getByLabel('Collections').fill('recovery tests');
+  await drawer
+    .getByLabel('Private notes')
+    .fill('Keep this note after restoring.');
+  await drawer.getByRole('button', { name: 'In progress' }).click();
+  await drawer.getByRole('button', { name: 'Save item' }).click();
+
+  await expect(itemInList(page, title)).toBeVisible();
+};
+
+const openItemDetail = async (page: Page, title = TITLE): Promise<void> => {
+  await itemInList(page, title).click();
+  await expect(
+    page.getByRole('complementary', { name: 'Selected item details' }),
+  ).toBeVisible();
+};
+
+const clearArchive = async (page: Page): Promise<void> => {
+  await page.evaluate(
+    (databaseName) =>
+      new Promise<void>((resolve, reject) => {
+        const request = window.indexedDB.deleteDatabase(databaseName);
+        request.onsuccess = () => resolve();
+        request.onerror = () =>
+          reject(request.error ?? new Error('Could not clear IndexedDB'));
+        request.onblocked = () =>
+          reject(new Error('IndexedDB is blocked by another open connection'));
+      }),
+    ARCHIVE_DATABASE_NAME,
+  );
+};
+
+const openManagePage = (page: Page, name: 'Export' | 'Import') =>
+  page
+    .getByRole('navigation', { name: 'Secondary navigation' })
+    .getByRole('button', { name, exact: true })
+    .click();
+
+test.beforeEach(async ({ page }) => {
+  await completeOnboarding(page);
+  await page.goto(APP_PATH);
+  await expect(page.getByRole('button', { name: 'New item' })).toBeVisible();
+});
+
+test('exports, clears, and restores a complete local archive', async ({
+  page,
+}, testInfo) => {
+  await addItem(page);
+  await openItemDetail(page);
+  await page.getByRole('button', { name: 'Open page' }).click();
+
+  const progress = page.getByLabel('Adjust progress percentage');
+  await progress.press('Home');
+  await progress.press('ArrowRight');
+  await expect(progress).toHaveValue('1');
+
+  await page.reload();
+  await expect(itemInList(page, TITLE)).toBeVisible();
+
+  await openManagePage(page, 'Export');
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export now' }).click();
+  const download = await downloadPromise;
+  const backupPath = testInfo.outputPath(download.suggestedFilename());
+  await download.saveAs(backupPath);
+
+  expect(download.suggestedFilename()).toMatch(
+    /^open-personal-tracking-backup-.*\.json$/,
+  );
+  await expect(page.getByRole('status')).toHaveText(
+    'Backup downloaded. Keep this file somewhere you control.',
+  );
+
+  await clearArchive(page);
+  await page.reload();
+  await expect(page.getByText('Nothing tracked yet')).toBeVisible();
+
+  await openManagePage(page, 'Import');
+  page.once('dialog', (dialog) => dialog.accept());
+  await page.locator('input[type="file"]').setInputFiles(backupPath!);
+
+  await expect(page.getByRole('status')).toHaveText(
+    /^Restored 1 item from open-personal-tracking-backup-.*\.json\.$/,
+  );
+
+  await page
+    .getByRole('navigation', { name: 'Primary navigation' })
+    .getByRole('button', { name: /^Library/ })
+    .first()
+    .click();
+  await openItemDetail(page);
+  await page.getByRole('button', { name: 'Open page' }).click();
+  await expect(page.getByLabel('Adjust progress percentage')).toHaveValue('1');
+  await page.keyboard.press('Escape');
+  await page
+    .getByRole('complementary', { name: 'Selected item details' })
+    .getByRole('button', { name: 'Edit' })
+    .click();
+
+  const drawer = page.getByRole('dialog', { name: 'New item' });
+  await expect(drawer.getByLabel('Rating')).toHaveValue('4.5');
+  await expect(drawer.getByLabel('Tags')).toHaveValue(
+    'science fiction, favourite',
+  );
+  await expect(drawer.getByLabel('Collections')).toHaveValue('recovery tests');
+  await expect(drawer.getByLabel('Private notes')).toHaveValue(
+    'Keep this note after restoring.',
+  );
+});
+
+test('keeps the existing archive when a backup file is invalid', async ({
+  page,
+}) => {
+  await addItem(page, 'Existing archive item');
+  await openManagePage(page, 'Import');
+  await page.locator('input[type="file"]').setInputFiles({
+    name: 'invalid-backup.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from('{ this is not JSON'),
+  });
+
+  await expect(page.getByText('Could not restore this backup')).toContainText(
+    'Could not restore this backup. Your current local archive was not changed',
+  );
+
+  await page
+    .getByRole('navigation', { name: 'Primary navigation' })
+    .getByRole('button', { name: /^Library/ })
+    .first()
+    .click();
+  await expect(itemInList(page, 'Existing archive item')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.63.0",
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
@@ -626,6 +627,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2650,6 +2667,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,17 +7,19 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
-    "lint": "eslint src tests --max-warnings=0",
-    "format": "prettier --write .github scripts src tests web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
-    "format:check": "prettier --check .github scripts src tests web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
+    "lint": "eslint src tests e2e playwright.config.ts --max-warnings=0",
+    "format": "prettier --write .github scripts src tests e2e web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
+    "format:check": "prettier --check .github scripts src tests e2e web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "dependencies": {
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.63.0",
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCI = Boolean(process.env.CI);
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev --prefix web -- --hostname 127.0.0.1',
+    url: 'http://127.0.0.1:3000/app-shell',
+    reuseExistingServer: !isCI,
+    timeout: 120_000,
+  },
+});

--- a/src/application/archive-application.ts
+++ b/src/application/archive-application.ts
@@ -9,6 +9,10 @@ import {
   type UserPreferences,
 } from '../domain/archive.js';
 import { createHistoryEntry } from '../domain/search.js';
+import {
+  createArchiveBackup,
+  prepareArchiveRestore,
+} from './archive-backup.js';
 
 export interface ArchivePersistence {
   load(): Promise<ArchiveSnapshot | null>;
@@ -94,6 +98,20 @@ export class ArchiveApplication {
 
   async load(): Promise<ArchiveSnapshot> {
     return (await this.persistence.load()) ?? createEmptyArchive();
+  }
+
+  exportBackup(archive: ArchiveSnapshot): string {
+    return createArchiveBackup(archive);
+  }
+
+  prepareRestore(backup: string): ArchiveSnapshot {
+    return prepareArchiveRestore(backup);
+  }
+
+  async restoreBackup(backup: ArchiveSnapshot): Promise<ArchiveSnapshot> {
+    const normalized = parseArchiveSnapshot(backup);
+    await this.persistence.save(normalized);
+    return normalized;
   }
 
   async createItem(

--- a/src/application/archive-backup.ts
+++ b/src/application/archive-backup.ts
@@ -1,0 +1,25 @@
+import {
+  parseArchiveSnapshot,
+  restoreArchiveSnapshot,
+  serializeArchiveSnapshot,
+  type ArchiveSnapshot,
+} from '../domain/archive.js';
+
+/** Serializes a complete, validated archive without accessing browser storage. */
+export const createArchiveBackup = (archive: ArchiveSnapshot): string =>
+  serializeArchiveSnapshot(parseArchiveSnapshot(archive));
+
+/**
+ * Parses, migrates, and validates a backup before any caller can replace local
+ * data. Future schemas are rejected rather than being coerced or discarded.
+ */
+export const prepareArchiveRestore = (backup: string): ArchiveSnapshot => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(backup) as unknown;
+  } catch {
+    throw new Error('Backup file is not valid JSON');
+  }
+
+  return restoreArchiveSnapshot(parsed);
+};

--- a/src/domain/archive.ts
+++ b/src/domain/archive.ts
@@ -368,7 +368,11 @@ export const migrateArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
     return migrate_v0_to_v1(value);
   }
 
-  return createEmptyArchive();
+  if (version === CURRENT_SCHEMA_VERSION) {
+    throw new Error('Invalid archive snapshot for the current schema version');
+  }
+
+  throw new Error(`Unsupported archive schema version: ${version}`);
 };
 
 export const parseArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
@@ -380,6 +384,22 @@ export const parseArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
   }
 
   return migrateArchiveSnapshot(parsed.data);
+};
+
+/** Migrates and validates an imported or stored snapshot without accepting future schemas. */
+export const restoreArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
+  if (value && typeof value === 'object') {
+    const schemaVersion = (value as Record<string, unknown>).schemaVersion;
+    if (
+      typeof schemaVersion === 'number' &&
+      Number.isInteger(schemaVersion) &&
+      schemaVersion > CURRENT_SCHEMA_VERSION
+    ) {
+      throw new Error(`Unsupported archive schema version: ${schemaVersion}`);
+    }
+  }
+
+  return parseArchiveSnapshot(migrateArchiveSnapshot(value));
 };
 
 export const serializeArchiveSnapshot = (snapshot: ArchiveSnapshot): string =>

--- a/src/storage/archive-store.ts
+++ b/src/storage/archive-store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import {
   parseArchiveSnapshot,
+  restoreArchiveSnapshot,
   serializeArchiveSnapshot,
   type ArchiveSnapshot,
 } from '../domain/archive.js';
@@ -52,7 +53,7 @@ export const loadArchiveSnapshot = async (
   const raw = await readFile(filePath, 'utf8');
   const parsed = JSON.parse(raw) as unknown;
 
-  return parseArchiveSnapshot(parsed);
+  return restoreArchiveSnapshot(parsed);
 };
 
 export const exportArchiveBackup = async (

--- a/src/storage/browser-archive-store.ts
+++ b/src/storage/browser-archive-store.ts
@@ -1,7 +1,6 @@
 import {
-  CURRENT_SCHEMA_VERSION,
-  migrateArchiveSnapshot,
   parseArchiveSnapshot,
+  restoreArchiveSnapshot,
   type ArchiveSnapshot,
 } from '../domain/archive.js';
 
@@ -57,21 +56,6 @@ const openDatabase = (indexedDB: IDBFactory): Promise<IDBDatabase> =>
       );
   });
 
-const migrateStoredSnapshot = (value: unknown): ArchiveSnapshot => {
-  if (value && typeof value === 'object') {
-    const schemaVersion = (value as Record<string, unknown>).schemaVersion;
-    if (
-      typeof schemaVersion === 'number' &&
-      Number.isInteger(schemaVersion) &&
-      schemaVersion > CURRENT_SCHEMA_VERSION
-    ) {
-      throw new Error(`Unsupported archive schema version: ${schemaVersion}`);
-    }
-  }
-
-  return parseArchiveSnapshot(migrateArchiveSnapshot(value));
-};
-
 const storedSnapshot = (record: unknown): unknown => {
   if (
     !record ||
@@ -117,7 +101,7 @@ export class BrowserArchiveStore {
         | undefined;
       await completed;
 
-      return record ? migrateStoredSnapshot(storedSnapshot(record)) : null;
+      return record ? restoreArchiveSnapshot(storedSnapshot(record)) : null;
     } finally {
       database.close();
     }

--- a/tests/archive-application.test.ts
+++ b/tests/archive-application.test.ts
@@ -4,6 +4,7 @@ import { ArchiveApplication } from '../src/application/archive-application.js';
 import { loadLocalArchive } from '../src/application/local-archive-application.js';
 import {
   createEmptyArchive,
+  createItem,
   type ArchiveSnapshot,
 } from '../src/domain/archive.js';
 
@@ -161,5 +162,104 @@ describe('archive application', () => {
       loadLocalArchive(new ArchiveApplication(persistence)),
     ).rejects.toThrow('Storage is unavailable');
     expect(values.has(key)).toBe(true);
+  });
+
+  it('recovers the complete archive from an exported local backup', async () => {
+    const persistence = new MemoryArchivePersistence();
+    const application = new ArchiveApplication(persistence);
+    const created = await application.createItem(await application.load(), {
+      id: 'dune',
+      title: 'Dune',
+      category: 'Book',
+      progress: { current: 184, target: 688, unit: 'pages' },
+      rating: 5,
+      notes: ['Read before the film'],
+      tags: ['science fiction'],
+      collections: ['favorites'],
+      attributes: { creator: 'Frank Herbert' },
+    });
+    const archive = await application.updatePreferences(created, {
+      displayName: 'Ludovico',
+      locale: 'it',
+      activities: ['books'],
+      favoriteGenres: ['Science fiction'],
+      placeholderCovers: false,
+      onboardingCompleted: true,
+    });
+
+    const backup = application.exportBackup(archive);
+    await persistence.clear();
+
+    const restored = await application.restoreBackup(
+      application.prepareRestore(backup),
+    );
+
+    expect(await application.load()).toEqual(restored);
+    expect(restored).toEqual(archive);
+  });
+
+  it('keeps the current archive when a backup is malformed, invalid, or newer than the app', async () => {
+    const persistence = new MemoryArchivePersistence();
+    const application = new ArchiveApplication(persistence);
+    const archive = await application.createItem(await application.load(), {
+      id: 'dune',
+      title: 'Dune',
+      category: 'Book',
+      progress: { current: 0, unit: 'pages' },
+    });
+
+    expect(() => application.prepareRestore('{not JSON')).toThrow(
+      'Backup file is not valid JSON',
+    );
+    expect(() =>
+      application.prepareRestore(
+        JSON.stringify({
+          schemaVersion: 1,
+          exportedAt: new Date().toISOString(),
+          items: [],
+        }),
+      ),
+    ).toThrow('Invalid archive snapshot for the current schema version');
+    expect(() =>
+      application.prepareRestore(
+        JSON.stringify({
+          schemaVersion: 2,
+          exportedAt: new Date().toISOString(),
+          items: [],
+          collections: [],
+          history: [],
+        }),
+      ),
+    ).toThrow('Unsupported archive schema version: 2');
+
+    expect(await application.load()).toEqual(archive);
+  });
+
+  it('keeps the current archive when a validated backup cannot be persisted', async () => {
+    const persistence = new MemoryArchivePersistence();
+    const application = new ArchiveApplication(persistence);
+    const current = await application.createItem(await application.load(), {
+      id: 'dune',
+      title: 'Dune',
+      category: 'Book',
+      progress: { current: 0, unit: 'pages' },
+    });
+    const replacement = createEmptyArchive();
+    replacement.items.push(
+      createItem({
+        id: 'earthsea',
+        title: 'A Wizard of Earthsea',
+        category: 'Book',
+        progress: { current: 0, unit: 'pages' },
+      }),
+    );
+    persistence.save = async () => {
+      throw new Error('Storage is unavailable');
+    };
+
+    await expect(application.restoreBackup(replacement)).rejects.toThrow(
+      'Storage is unavailable',
+    );
+    expect(await application.load()).toEqual(current);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,10 @@
     "resolveJsonModule": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "e2e/**/*.ts",
+    "playwright.config.ts"
+  ]
 }

--- a/web/app/app-shell/page.tsx
+++ b/web/app/app-shell/page.tsx
@@ -12,7 +12,7 @@ import {
   UserRound,
   X,
 } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   createLocalArchiveApplication,
@@ -237,7 +237,9 @@ export default function AppShellPage() {
   const [archive, setArchive] = useState<ArchiveSnapshot | null>(null);
   const [storageError, setStorageError] = useState<string | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
+  const [backupStatus, setBackupStatus] = useState<string | null>(null);
   const application = useRef<ArchiveApplication | null>(null);
+  const restoreInput = useRef<HTMLInputElement | null>(null);
   const preferenceSaveQueue = useRef<Promise<void>>(Promise.resolve());
   const preferenceSaveRevision = useRef(0);
 
@@ -520,6 +522,68 @@ export default function AppShellPage() {
     } catch (error) {
       setOperationError(
         error instanceof Error ? error.message : 'Could not update progress',
+      );
+    }
+  };
+
+  const handleExportBackup = () => {
+    if (!archive || !application.current) return;
+
+    try {
+      const backup = application.current.exportBackup(archive);
+      const file = new Blob([backup], { type: 'application/json' });
+      const url = URL.createObjectURL(file);
+      const download = document.createElement('a');
+      download.href = url;
+      download.download = `open-personal-tracking-backup-${archive.exportedAt.slice(0, 10)}.json`;
+      document.body.append(download);
+      download.click();
+      download.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+      setOperationError(null);
+      setBackupStatus(
+        'Backup downloaded. Keep this file somewhere you control.',
+      );
+    } catch (error) {
+      setOperationError(
+        error instanceof Error
+          ? `Could not export your backup: ${error.message}`
+          : 'Could not export your backup',
+      );
+    }
+  };
+
+  const handleRestoreBackup = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file || !application.current) return;
+
+    try {
+      const prepared = application.current.prepareRestore(await file.text());
+      const itemLabel = prepared.items.length === 1 ? 'item' : 'items';
+      if (
+        !window.confirm(
+          `Restore ${prepared.items.length} ${itemLabel} from “${file.name}”? This replaces the current local archive. Export a backup first if you need to keep the current data.`,
+        )
+      ) {
+        return;
+      }
+
+      const restored = await application.current.restoreBackup(prepared);
+      setArchive(restored);
+      setSelectedId(null);
+      setDetailView('summary');
+      setSelectedEpisode(null);
+      setCompletedEpisodesByItem({});
+      setOperationError(null);
+      setBackupStatus(
+        `Restored ${restored.items.length} ${restored.items.length === 1 ? 'item' : 'items'} from ${file.name}.`,
+      );
+    } catch (error) {
+      setOperationError(
+        error instanceof Error
+          ? `Could not restore this backup. Your current local archive was not changed: ${error.message}`
+          : 'Could not restore this backup. Your current local archive was not changed.',
       );
     }
   };
@@ -1420,15 +1484,26 @@ export default function AppShellPage() {
                       Keep everything in a durable, readable format you own.
                     </p>
                   </div>
-                  <button className="primary-btn" type="button">
+                  <button
+                    className="primary-btn"
+                    type="button"
+                    onClick={handleExportBackup}
+                  >
                     Export now
                   </button>
                 </div>
+                {backupStatus && activeNav === 'export' && (
+                  <p className="empty-state" role="status">
+                    {backupStatus}
+                  </p>
+                )}
                 <div className="screen-grid">
                   <div className="summary-card">
                     <span className="eyebrow">Last export</span>
-                    <strong>—</strong>
-                    <span>No backup exported yet</span>
+                    <strong>On demand</strong>
+                    <span>
+                      Download a complete archive whenever you need one
+                    </span>
                   </div>
                   <div className="summary-card">
                     <span className="eyebrow">Format</span>
@@ -1609,16 +1684,42 @@ export default function AppShellPage() {
             )}
 
             {activeNav === 'import' && (
-              <div className="screen-hero">
-                <div>
-                  <span className="eyebrow">Import</span>
-                  <h2>Bring your archive in</h2>
-                  <p>Import CSV, JSON, or a previous export backup.</p>
+              <>
+                <div className="screen-hero">
+                  <div>
+                    <span className="eyebrow">Restore</span>
+                    <h2>Restore a local backup</h2>
+                    <p>
+                      Choose a JSON backup exported by this app. It is validated
+                      before it can replace your current local archive.
+                    </p>
+                  </div>
+                  <button
+                    className="primary-btn"
+                    type="button"
+                    onClick={() => restoreInput.current?.click()}
+                  >
+                    Select backup
+                  </button>
+                  <input
+                    ref={restoreInput}
+                    type="file"
+                    accept="application/json,.json"
+                    onChange={(event) => void handleRestoreBackup(event)}
+                    hidden
+                  />
                 </div>
-                <button className="primary-btn" type="button">
-                  Select file
-                </button>
-              </div>
+                <p className="empty-state">
+                  Restoring replaces the current archive only after the backup
+                  passes migration and validation. Invalid or unsupported files
+                  leave your current data unchanged.
+                </p>
+                {backupStatus && (
+                  <p className="empty-state" role="status">
+                    {backupStatus}
+                  </p>
+                )}
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## What

Close #45

- Added complete local JSON backup export and restore in the web app.
- Added Playwright end-to-end coverage for the disaster-recovery flow.
- Added Chromium E2E execution to GitHub Actions.

## Why

Users need a reliable way to retain ownership of their local archive and recover it after browser-local data is removed. The previous UI did not provide a complete user-facing export and restore path.

## How

- Reused the existing `ArchiveSnapshot` format and migration/validation pipeline.
- Kept backup serialization and restore preparation in the application layer, outside React.
- Restore parses, migrates, and validates the selected JSON before persistence replaces the active archive.
- Added a confirmation before replacement and clear status/error messages.
- Configured Playwright with isolated browser contexts, Chromium-only CI execution, retries/traces on CI, and failure screenshots/videos.
- The E2E flow creates an item with progress, rating, notes, tags, and collections; reloads; exports; clears IndexedDB; restores; and verifies the recovered data.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test` — 25 tests passed
- `npm run build --prefix web`
- `npm run test:e2e` — 2 Playwright tests passed:
  - complete export, deletion, and restore recovery flow
  - invalid JSON leaves the existing archive unchanged

## Data impact

Yes. This introduces a user-facing backup and restore contract for the complete persisted archive.

Restore does not modify current data until the selected file has been parsed, migrated, and validated successfully. Malformed, invalid, unsupported, or failed restores show a recoverable error and leave the existing local archive unchanged. The feature remains local-first: it requires no account or network request.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed
- [x] Accessibility considered for UI/interaction changes
- [x] No unrelated refactors bundled into this PR