### PR TITLE
feat: implement parent and sub-unit tracking with derived progress an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.0.0/
 
 ### Added
 
+- Persisted parent/sub-unit tracking with derived parent progress, reopening, and independent watch/rewatch history entries.
 - Complete browser-local JSON backup export and restore, with validation and migration before local data is replaced.
 - Automated linting and formatting checks for contributions and pull requests, with staged-file checks before each commit.
 - Series tracking in the app shell, with season and episode views.

--- a/DATA_FORMAT.md
+++ b/DATA_FORMAT.md
@@ -26,16 +26,39 @@ Backups currently serialize the complete, versioned `ArchiveSnapshot` directly:
 
 ```json
 {
-	"schemaVersion": 1,
-	"exportedAt": "2026-08-27T00:00:00.000Z",
-	"items": [],
-	"collections": [],
-	"history": [],
-	"preferences": {}
+  "schemaVersion": 2,
+  "exportedAt": "2026-08-27T00:00:00.000Z",
+  "items": [],
+  "collections": [],
+  "history": [],
+  "preferences": {}
 }
 ```
 
 Restore rejects backups from a future schema version. It migrates supported legacy snapshots and validates the result before replacing local data.
+
+## Parent and sub-unit tracking
+
+Items may include a `subunits` hierarchy for sequential media. A sub-unit has a
+stable `id`, a `kind` (`season`, `episode`, `chapter`, or `unit`), a title,
+and an optional `parentId`. A season is a container; episodes and chapters are
+normally leaves.
+
+Only leaf sub-units persist current-cycle completion (`completed`) and an
+all-time `watchCount`. Container state is never stored independently. For an
+item with sub-units, the archive derives its parent state as follows:
+
+- `progress.current` is the number of completed leaves;
+- `progress.target` is the total number of leaves;
+- the parent is `completed` only when every leaf is completed;
+- it is `in_progress` after any current or previous watch; otherwise it is
+  `planned`.
+
+Reopening a completed parent clears `completed` on every leaf and sets parent
+progress to zero, but preserves every `watchCount` and history entry. A later
+watch of a previously watched leaf creates a distinct `rewatched` history
+entry. Invalid hierarchies (duplicate IDs, missing parents, cycles, or state on
+container units) are rejected at import and persistence boundaries.
 
 ## Requirements
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,6 +93,12 @@ The web adapter follows the same rule: UI components must not access IndexedDB d
 
 Backup export and restore use the same application boundary. The UI downloads or reads a local JSON file, while `ArchiveApplication` serializes or prepares a complete `ArchiveSnapshot`. A restore is parsed, migrated, and validated before the persistence adapter receives it; invalid and unsupported backups leave the stored archive untouched.
 
+Parent/sub-unit tracking is also a domain invariant. Items persist a generic
+sub-unit hierarchy while the domain derives parent progress and completion from
+leaf units. `ArchiveApplication` records watches, rewatches, and reopening as
+separate history entries; React must not maintain an independent source of
+episode completion state.
+
 ## Generic item model
 
 Avoid tables and domain logic tied to a single media category.
@@ -101,16 +107,16 @@ Conceptual model:
 
 ```ts
 type Item = {
-	id: string
-	type: string
-	title: string
-	description?: string
-	imageUrl?: string
-	externalIds: Record<string, string>
-	metadata: Record<string, unknown>
-	createdAt: string
-	updatedAt: string
-}
+  id: string;
+  type: string;
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  externalIds: Record<string, string>;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
 ```
 
 Specialized metadata must be normalized at provider boundaries.
@@ -123,10 +129,10 @@ Example:
 
 ```ts
 interface ItemRepository {
-	findById(id: string): Promise<Item | null>
-	findAll(): Promise<Array<Item>>
-	save(item: Item): Promise<void>
-	delete(id: string): Promise<void>
+  findById(id: string): Promise<Item | null>;
+  findAll(): Promise<Array<Item>>;
+  save(item: Item): Promise<void>;
+  delete(id: string): Promise<void>;
 }
 ```
 

--- a/docs/PRODUCT_REQUIREMENTS.md
+++ b/docs/PRODUCT_REQUIREMENTS.md
@@ -132,6 +132,11 @@ The core model must not assume that progress is always episode-based.
 
 Series progress must be derived from episodes, not from an unrelated manual percentage. A season is completed only when every episode it contains is completed. Users must be able to open an episode and view its own metadata and tracking state without losing the context of the parent series and season.
 
+The same hierarchy applies to every sequential category. A parent with tracked
+sub-units derives its status and progress from leaf units. Reopening a
+completed parent clears only current-cycle leaf completion; it never removes
+the historical watch records needed to distinguish a later rewatch.
+
 ## Personal notes vs public comments
 
 Private notes belong to open-personal-tracking Core.

--- a/docs/rfcs/0003-parent-subunit-tracking.md
+++ b/docs/rfcs/0003-parent-subunit-tracking.md
@@ -1,0 +1,55 @@
+# RFC 0003: Parent and sub-unit tracking
+
+## Status
+
+Draft
+
+## Summary
+
+Sequential media is represented by a generic hierarchy of sub-units owned by
+one archive item. Parent progress and completion are derived from leaf units,
+so a series, season, chapter group, or other container cannot contradict the
+state of the units it contains.
+
+## Decision
+
+Each item can persist `subunits`. A unit has a stable ID, kind, title, optional
+parent ID, optional ordering position, current-cycle completion, and an
+all-time watch count. Units can be nested; only leaves may carry completion or
+watch state.
+
+For an item with at least one leaf unit:
+
+- parent progress is completed leaves over all leaves;
+- the parent is completed only when every leaf is completed;
+- the parent is in progress after any current or historic leaf watch;
+- otherwise the parent is planned.
+
+`watchSubunit` creates a `watched` history entry for the first watch and a
+`rewatched` entry for every later watch. Both retain the target sub-unit ID.
+When a completed parent is reopened, all leaf `completed` values become false,
+parent progress becomes zero, watch counts remain unchanged, and a `reopened`
+history entry is added.
+
+## Validation and migration
+
+Archive schema version 2 adds `subunits` and expanded history actions. Version
+1 archives migrate with an empty sub-unit list and retain their existing manual
+progress. At every parse, import, restore, and persistence boundary the domain
+rejects duplicate IDs, missing parents, cycles, and completion state on a
+container. It normalizes parent status and progress from valid leaves.
+
+## Alternatives considered
+
+- Independent flags on parent, seasons, and episodes: these allow permanent
+  contradictions and cannot determine which state is authoritative.
+- A TV-only episode model: this would exclude anime, chapters, courses, and
+  future sequential categories.
+- Replacing prior history on rewatch: this loses the user-owned record of each
+  completed pass.
+
+## Consequences
+
+The portable `ArchiveSnapshot` is now schema version 2. Clients should use the
+application operations for watch and reopen actions rather than manually
+setting the parent status of a hierarchical item.

--- a/src/application/archive-application.ts
+++ b/src/application/archive-application.ts
@@ -1,11 +1,15 @@
 import {
   createEmptyArchive,
   createItem,
+  getLeafTrackingUnits,
+  normalizeItemTracking,
   parseArchiveSnapshot,
   type ArchiveSnapshot,
   type CreateItemInput,
+  type HistoryEntry,
   type Item,
   type Progress,
+  type TrackingUnit,
   type UserPreferences,
 } from '../domain/archive.js';
 import { createHistoryEntry } from '../domain/search.js';
@@ -42,13 +46,14 @@ export type ItemUpdate = Partial<
 const withHistory = (
   archive: ArchiveSnapshot,
   itemId: string,
-  action: 'created' | 'updated' | 'completed' | 'deleted',
+  action: HistoryEntry['action'],
   summary: string,
+  subunitId?: string,
 ): ArchiveSnapshot => ({
   ...archive,
   history: [
     ...archive.history,
-    createHistoryEntry({ itemId, action, summary }),
+    createHistoryEntry({ itemId, subunitId, action, summary }),
   ],
 });
 
@@ -118,7 +123,7 @@ export class ArchiveApplication {
     archive: ArchiveSnapshot,
     input: CreateItemInput,
   ): Promise<ArchiveSnapshot> {
-    const item = createItem(input);
+    const item = normalizeItemTracking(createItem(input));
     const next = withHistory(
       syncCollectionReferences(
         { ...archive, items: [...archive.items, item] },
@@ -142,13 +147,15 @@ export class ArchiveApplication {
       throw new Error(`Cannot update missing item: ${itemId}`);
     }
 
-    const updated = createItem({
-      ...current,
-      ...update,
-      id: current.id,
-      createdAt: current.createdAt,
-      updatedAt: new Date().toISOString(),
-    });
+    const updated = normalizeItemTracking(
+      createItem({
+        ...current,
+        ...update,
+        id: current.id,
+        createdAt: current.createdAt,
+        updatedAt: new Date().toISOString(),
+      }),
+    );
     const action =
       updated.status === 'completed' && current.status !== 'completed'
         ? 'completed'
@@ -179,6 +186,113 @@ export class ArchiveApplication {
     progress: Progress,
   ): Promise<ArchiveSnapshot> {
     return this.updateItem(archive, itemId, { progress });
+  }
+
+  /** Records a watch event for one leaf sub-unit and derives the parent state. */
+  async watchSubunit(
+    archive: ArchiveSnapshot,
+    itemId: string,
+    subunitId: string,
+  ): Promise<ArchiveSnapshot> {
+    const current = archive.items.find((item) => item.id === itemId);
+    if (!current) {
+      throw new Error(`Cannot watch a sub-unit of missing item: ${itemId}`);
+    }
+
+    const leaf = getLeafTrackingUnits(current.subunits).find(
+      (unit) => unit.id === subunitId,
+    );
+    if (!leaf) {
+      throw new Error(
+        `Cannot watch missing or container sub-unit: ${subunitId}`,
+      );
+    }
+
+    const watched: TrackingUnit = {
+      ...leaf,
+      completed: true,
+      watchCount: leaf.watchCount + 1,
+    };
+    const updated = normalizeItemTracking(
+      createItem({
+        ...current,
+        subunits: current.subunits.map((unit) =>
+          unit.id === subunitId ? watched : unit,
+        ),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    const action = leaf.watchCount === 0 ? 'watched' : 'rewatched';
+    let next = {
+      ...archive,
+      items: archive.items.map((item) => (item.id === itemId ? updated : item)),
+    };
+    next = withHistory(
+      next,
+      itemId,
+      action,
+      `${action === 'watched' ? 'Watched' : 'Rewatched'} ${leaf.title} in ${current.title}`,
+      subunitId,
+    );
+    if (current.status !== 'completed' && updated.status === 'completed') {
+      next = withHistory(
+        next,
+        itemId,
+        'completed',
+        `Completed ${updated.title}`,
+      );
+    }
+
+    return this.persist(next);
+  }
+
+  /**
+   * Starts a new pass through a completed hierarchy. Past watches remain in
+   * history and in each leaf's watch count, while current-cycle completion is
+   * cleared for every leaf.
+   */
+  async reopenTrackedItem(
+    archive: ArchiveSnapshot,
+    itemId: string,
+  ): Promise<ArchiveSnapshot> {
+    const current = archive.items.find((item) => item.id === itemId);
+    if (!current) {
+      throw new Error(`Cannot reopen missing item: ${itemId}`);
+    }
+    if (current.status !== 'completed') {
+      throw new Error(`Cannot reopen an item that is not completed: ${itemId}`);
+    }
+
+    const leaves = getLeafTrackingUnits(current.subunits);
+    if (leaves.length === 0) {
+      throw new Error(
+        `Cannot reopen an item without tracked sub-units: ${itemId}`,
+      );
+    }
+
+    const leafIds = new Set(leaves.map((unit) => unit.id));
+    const updated = normalizeItemTracking(
+      createItem({
+        ...current,
+        subunits: current.subunits.map((unit) =>
+          leafIds.has(unit.id) ? { ...unit, completed: false } : unit,
+        ),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    const next = withHistory(
+      {
+        ...archive,
+        items: archive.items.map((item) =>
+          item.id === itemId ? updated : item,
+        ),
+      },
+      itemId,
+      'reopened',
+      `Reopened ${updated.title}`,
+    );
+
+    return this.persist(next);
   }
 
   async updatePreferences(

--- a/src/domain/archive.ts
+++ b/src/domain/archive.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const CURRENT_SCHEMA_VERSION = 1 as const;
+export const CURRENT_SCHEMA_VERSION = 2 as const;
 
 export const StatusSchema = z.enum([
   'planned',
@@ -51,6 +51,30 @@ export const ProgressSchema = z.object({
 });
 export type Progress = z.infer<typeof ProgressSchema>;
 
+export const TrackingUnitKindSchema = z.enum([
+  'season',
+  'episode',
+  'chapter',
+  'unit',
+]);
+export type TrackingUnitKind = z.infer<typeof TrackingUnitKindSchema>;
+
+/**
+ * A unit is part of a hierarchy owned by one item. Only leaf units carry
+ * completion state; container units (for example, seasons) derive it from
+ * their descendants.
+ */
+export const TrackingUnitSchema = z.object({
+  id: z.string().min(1),
+  kind: TrackingUnitKindSchema,
+  title: z.string().trim().min(1),
+  parentId: z.string().min(1).optional(),
+  position: z.number().int().nonnegative().optional(),
+  completed: z.boolean().default(false),
+  watchCount: z.number().int().nonnegative().default(0),
+});
+export type TrackingUnit = z.infer<typeof TrackingUnitSchema>;
+
 export const ItemSchema = z.object({
   id: z.string().min(1),
   type: z.string().min(1),
@@ -68,6 +92,7 @@ export const ItemSchema = z.object({
   attributes: z.record(z.string(), AttributeValueSchema),
   externalIds: z.record(z.string(), z.string()),
   imageUrl: z.string().url().optional(),
+  subunits: z.array(TrackingUnitSchema).default([]),
 });
 export type Item = z.infer<typeof ItemSchema>;
 
@@ -84,19 +109,37 @@ export type Collection = z.infer<typeof CollectionSchema>;
 export const HistoryEntrySchema = z.object({
   id: z.string().min(1),
   itemId: z.string().min(1),
-  action: z.enum(['created', 'updated', 'completed', 'deleted', 'imported']),
+  subunitId: z.string().min(1).optional(),
+  action: z.enum([
+    'created',
+    'updated',
+    'completed',
+    'deleted',
+    'imported',
+    'watched',
+    'rewatched',
+    'reopened',
+  ]),
   timestamp: z.string().datetime(),
   summary: z.string(),
 });
 export type HistoryEntry = z.infer<typeof HistoryEntrySchema>;
 
-export const ArchiveSnapshotSchema = z.object({
-  schemaVersion: z.number().int().nonnegative(),
+const ArchiveSnapshotFieldsSchema = z.object({
   exportedAt: z.string().datetime(),
   items: z.array(ItemSchema),
   collections: z.array(CollectionSchema),
   history: z.array(HistoryEntrySchema),
   preferences: UserPreferencesSchema.default({}),
+});
+
+const ArchiveSnapshotV1Schema = ArchiveSnapshotFieldsSchema.extend({
+  schemaVersion: z.literal(1),
+});
+type ArchiveSnapshotV1 = z.infer<typeof ArchiveSnapshotV1Schema>;
+
+export const ArchiveSnapshotSchema = ArchiveSnapshotFieldsSchema.extend({
+  schemaVersion: z.literal(CURRENT_SCHEMA_VERSION),
 });
 export type ArchiveSnapshot = z.infer<typeof ArchiveSnapshotSchema>;
 
@@ -126,6 +169,7 @@ export type CreateItemInput = {
   attributes?: Record<string, AttributeValue>;
   externalIds?: Record<string, string>;
   imageUrl?: string;
+  subunits?: TrackingUnit[];
 };
 
 export const createEmptyArchive = (): ArchiveSnapshot => ({
@@ -156,6 +200,7 @@ export const createItem = (input: CreateItemInput): Item => {
       attributes: z.record(z.string(), AttributeValueSchema).default({}),
       externalIds: z.record(z.string(), z.string()).default({}),
       imageUrl: z.string().url().optional(),
+      subunits: z.array(TrackingUnitSchema).default([]),
     })
     .parse(input);
 
@@ -182,10 +227,119 @@ export const createItem = (input: CreateItemInput): Item => {
     attributes: parsed.attributes,
     externalIds: parsed.externalIds,
     imageUrl: parsed.imageUrl,
+    subunits: parsed.subunits,
   };
 };
 
-const migrate_v0_to_v1 = (value: unknown): ArchiveSnapshot => {
+const trackingUnitIds = (units: TrackingUnit[]): Set<string> => {
+  const ids = new Set<string>();
+  for (const unit of units) {
+    if (ids.has(unit.id)) {
+      throw new Error(`Tracking units must have unique ids: ${unit.id}`);
+    }
+    ids.add(unit.id);
+  }
+  return ids;
+};
+
+const assertValidTrackingHierarchy = (units: TrackingUnit[]): void => {
+  const ids = trackingUnitIds(units);
+  const childrenByParent = new Map<string, TrackingUnit[]>();
+
+  for (const unit of units) {
+    if (unit.parentId) {
+      if (!ids.has(unit.parentId)) {
+        throw new Error(
+          `Tracking unit ${unit.id} references a missing parent: ${unit.parentId}`,
+        );
+      }
+      if (unit.parentId === unit.id) {
+        throw new Error(`Tracking unit ${unit.id} cannot parent itself`);
+      }
+      const children = childrenByParent.get(unit.parentId) ?? [];
+      children.push(unit);
+      childrenByParent.set(unit.parentId, children);
+    }
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (unit: TrackingUnit): void => {
+    if (visited.has(unit.id)) return;
+    if (visiting.has(unit.id)) {
+      throw new Error(`Tracking units contain a parent cycle at: ${unit.id}`);
+    }
+
+    visiting.add(unit.id);
+    if (unit.parentId) {
+      const parent = units.find((candidate) => candidate.id === unit.parentId);
+      if (parent) visit(parent);
+    }
+    visiting.delete(unit.id);
+    visited.add(unit.id);
+  };
+
+  for (const unit of units) visit(unit);
+
+  for (const unit of units) {
+    const hasChildren = childrenByParent.has(unit.id);
+    if (hasChildren && (unit.completed || unit.watchCount > 0)) {
+      throw new Error(
+        `Container tracking unit ${unit.id} cannot have completion state`,
+      );
+    }
+    if (unit.completed && unit.watchCount === 0) {
+      throw new Error(
+        `Completed tracking unit ${unit.id} must have at least one watch`,
+      );
+    }
+  }
+};
+
+export const getLeafTrackingUnits = (units: TrackingUnit[]): TrackingUnit[] => {
+  assertValidTrackingHierarchy(units);
+  const parentIds = new Set(
+    units.flatMap((unit) => (unit.parentId ? [unit.parentId] : [])),
+  );
+  return units.filter((unit) => !parentIds.has(unit.id));
+};
+
+/**
+ * Computes canonical parent tracking state from its leaf units. Items without
+ * sub-units retain their manually managed progress and status.
+ */
+export const normalizeItemTracking = (item: Item): Item => {
+  const leaves = getLeafTrackingUnits(item.subunits);
+  if (leaves.length === 0) return item;
+
+  const completedCount = leaves.filter((unit) => unit.completed).length;
+  const hasWatchHistory = leaves.some((unit) => unit.watchCount > 0);
+  const status: ItemStatus =
+    completedCount === leaves.length
+      ? 'completed'
+      : completedCount > 0 || hasWatchHistory
+        ? 'in_progress'
+        : 'planned';
+
+  return {
+    ...item,
+    status,
+    progress: {
+      current: completedCount,
+      target: leaves.length,
+      unit: 'subunits',
+    },
+  };
+};
+
+const normalizeArchiveTracking = (
+  snapshot: ArchiveSnapshot,
+): ArchiveSnapshot => ({
+  ...snapshot,
+  items: snapshot.items.map(normalizeItemTracking),
+});
+
+const migrate_v0_to_v1 = (value: unknown): ArchiveSnapshotV1 => {
   const legacy = LegacyArchiveSchema.parse(value);
   const items = Array.isArray(legacy.items)
     ? legacy.items.map((item) => {
@@ -279,7 +433,7 @@ const migrate_v0_to_v1 = (value: unknown): ArchiveSnapshot => {
     : [];
 
   return {
-    schemaVersion: CURRENT_SCHEMA_VERSION,
+    schemaVersion: 1,
     exportedAt: legacy.exportedAt ?? new Date().toISOString(),
     items,
     collections: Array.isArray(legacy.collections)
@@ -349,12 +503,20 @@ const migrate_v0_to_v1 = (value: unknown): ArchiveSnapshot => {
   };
 };
 
-export const migrateArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
-  const parsed = ArchiveSnapshotSchema.safeParse(value);
-  if (parsed.success) {
-    return parsed.data;
-  }
+const migrate_v1_to_v2 = (value: unknown): ArchiveSnapshot => {
+  const snapshot = ArchiveSnapshotV1Schema.parse(value);
 
+  return {
+    ...snapshot,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    items: snapshot.items.map((item) => ({
+      ...item,
+      subunits: item.subunits,
+    })),
+  };
+};
+
+export const migrateArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
   const legacy = LegacyArchiveSchema.safeParse(value);
   if (!legacy.success) {
     throw new Error(
@@ -365,10 +527,16 @@ export const migrateArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
   const version = legacy.data.schemaVersion ?? 0;
 
   if (version === 0) {
-    return migrate_v0_to_v1(value);
+    return migrate_v1_to_v2(migrate_v0_to_v1(value));
+  }
+
+  if (version === 1) {
+    return migrate_v1_to_v2(value);
   }
 
   if (version === CURRENT_SCHEMA_VERSION) {
+    const parsed = ArchiveSnapshotSchema.safeParse(value);
+    if (parsed.success) return parsed.data;
     throw new Error('Invalid archive snapshot for the current schema version');
   }
 
@@ -376,14 +544,16 @@ export const migrateArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
 };
 
 export const parseArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
-  const parsed = ArchiveSnapshotSchema.safeParse(value);
-  if (!parsed.success) {
-    throw new Error(
-      `Invalid archive snapshot: ${JSON.stringify(parsed.error.issues)}`,
-    );
+  try {
+    return normalizeArchiveTracking(migrateArchiveSnapshot(value));
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `Invalid archive snapshot: ${JSON.stringify(error.issues)}`,
+      );
+    }
+    throw error;
   }
-
-  return migrateArchiveSnapshot(parsed.data);
 };
 
 /** Migrates and validates an imported or stored snapshot without accepting future schemas. */
@@ -399,7 +569,7 @@ export const restoreArchiveSnapshot = (value: unknown): ArchiveSnapshot => {
     }
   }
 
-  return parseArchiveSnapshot(migrateArchiveSnapshot(value));
+  return parseArchiveSnapshot(value);
 };
 
 export const serializeArchiveSnapshot = (snapshot: ArchiveSnapshot): string =>

--- a/src/domain/search.ts
+++ b/src/domain/search.ts
@@ -15,6 +15,7 @@ export type HistoryAction = HistoryEntry['action'];
 export type HistoryEntryInput = {
   id?: string;
   itemId: string;
+  subunitId?: string;
   action: HistoryAction;
   timestamp?: string;
   summary: string;
@@ -23,6 +24,7 @@ export type HistoryEntryInput = {
 export const createHistoryEntry = (input: HistoryEntryInput): HistoryEntry => ({
   id: input.id ?? crypto.randomUUID(),
   itemId: input.itemId,
+  subunitId: input.subunitId,
   action: input.action,
   timestamp: input.timestamp ?? new Date().toISOString(),
   summary: input.summary,

--- a/tests/archive-application.test.ts
+++ b/tests/archive-application.test.ts
@@ -214,7 +214,7 @@ describe('archive application', () => {
     expect(() =>
       application.prepareRestore(
         JSON.stringify({
-          schemaVersion: 1,
+          schemaVersion: 2,
           exportedAt: new Date().toISOString(),
           items: [],
         }),
@@ -223,14 +223,14 @@ describe('archive application', () => {
     expect(() =>
       application.prepareRestore(
         JSON.stringify({
-          schemaVersion: 2,
+          schemaVersion: 3,
           exportedAt: new Date().toISOString(),
           items: [],
           collections: [],
           history: [],
         }),
       ),
-    ).toThrow('Unsupported archive schema version: 2');
+    ).toThrow('Unsupported archive schema version: 3');
 
     expect(await application.load()).toEqual(archive);
   });

--- a/tests/browser-archive-store.test.ts
+++ b/tests/browser-archive-store.test.ts
@@ -191,7 +191,7 @@ describe('browser archive storage', () => {
 
     const restored = await createStore(factory).load();
 
-    expect(restored?.schemaVersion).toBe(1);
+    expect(restored?.schemaVersion).toBe(2);
     expect(restored?.items[0]).toMatchObject({
       title: 'Dune',
       category: 'book',
@@ -225,7 +225,7 @@ describe('browser archive storage', () => {
   it('rejects an unsupported stored schema without modifying it', async () => {
     const factory = new TestIndexedDbFactory();
     const unsupported = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       exportedAt: new Date().toISOString(),
       items: [],
       collections: [],
@@ -234,7 +234,7 @@ describe('browser archive storage', () => {
     factory.seed(unsupported);
 
     await expect(createStore(factory).load()).rejects.toThrow(
-      'Unsupported archive schema version: 2',
+      'Unsupported archive schema version: 3',
     );
     expect(factory.rawValue()).toEqual({
       key: BROWSER_ARCHIVE_RECORD_KEY,

--- a/tests/domain-archive.test.ts
+++ b/tests/domain-archive.test.ts
@@ -127,6 +127,43 @@ describe('domain archive schema', () => {
     expect(migrated.collections[0].name).toBe('Favorites');
   });
 
+  it('migrates schema version 1 archives with manual progress unchanged', () => {
+    const migrated = migrateArchiveSnapshot({
+      schemaVersion: 1,
+      exportedAt: '2024-01-01T00:00:00.000Z',
+      items: [
+        {
+          id: 'dune',
+          type: 'book',
+          title: 'Dune',
+          category: 'Book',
+          status: 'in_progress',
+          progress: { current: 184, target: 688, unit: 'pages' },
+          notes: [],
+          tags: [],
+          collections: [],
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+          attributes: {},
+          externalIds: {},
+        },
+      ],
+      collections: [],
+      history: [],
+    });
+
+    expect(migrated).toMatchObject({
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      items: [
+        {
+          id: 'dune',
+          progress: { current: 184, target: 688, unit: 'pages' },
+          subunits: [],
+        },
+      ],
+    });
+  });
+
   it('rejects malformed archive snapshots', () => {
     expect(() =>
       parseArchiveSnapshot({

--- a/tests/storage-archive.test.ts
+++ b/tests/storage-archive.test.ts
@@ -55,7 +55,7 @@ describe('archive storage', () => {
     expect(restored.items[0].title).toBe('Dune');
     expect(restored.items[0].status).toBe('in_progress');
     expect(restored.items[0].attributes).toEqual({ author: 'Frank Herbert' });
-    expect(JSON.parse(readFileSync(filePath, 'utf8')).schemaVersion).toBe(1);
+    expect(JSON.parse(readFileSync(filePath, 'utf8')).schemaVersion).toBe(2);
   });
 
   it('exports a backup file and restores it after clearing local state', async () => {

--- a/tests/tracking-consistency.test.ts
+++ b/tests/tracking-consistency.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import { ArchiveApplication } from '../src/application/archive-application.js';
+import {
+  CURRENT_SCHEMA_VERSION,
+  createEmptyArchive,
+  createItem,
+  parseArchiveSnapshot,
+  type ArchiveSnapshot,
+} from '../src/domain/archive.js';
+
+class MemoryArchivePersistence {
+  snapshot: ArchiveSnapshot | null = null;
+
+  async load(): Promise<ArchiveSnapshot | null> {
+    return this.snapshot;
+  }
+
+  async save(snapshot: ArchiveSnapshot): Promise<void> {
+    this.snapshot = structuredClone(snapshot);
+  }
+
+  async clear(): Promise<void> {
+    this.snapshot = null;
+  }
+}
+
+const seriesInput = {
+  id: 'the-expanse',
+  title: 'The Expanse',
+  category: 'Series',
+  progress: { current: 99, target: 99, unit: 'episodes' },
+  status: 'completed' as const,
+  subunits: [
+    {
+      id: 'season-1',
+      kind: 'season' as const,
+      title: 'Season 1',
+      position: 1,
+      completed: false,
+      watchCount: 0,
+    },
+    {
+      id: 's1e1',
+      kind: 'episode' as const,
+      title: 'Dulcinea',
+      parentId: 'season-1',
+      position: 1,
+      completed: false,
+      watchCount: 0,
+    },
+    {
+      id: 's1e2',
+      kind: 'episode' as const,
+      title: 'The Big Empty',
+      parentId: 'season-1',
+      position: 2,
+      completed: false,
+      watchCount: 0,
+    },
+  ],
+};
+
+describe('parent and sub-unit tracking', () => {
+  it('derives completion from leaves, reopens consistently, and retains each watch event', async () => {
+    const application = new ArchiveApplication(new MemoryArchivePersistence());
+    const created = await application.createItem(
+      await application.load(),
+      seriesInput,
+    );
+
+    expect(created.items[0]).toMatchObject({
+      status: 'planned',
+      progress: { current: 0, target: 2, unit: 'subunits' },
+    });
+
+    const withFirstEpisode = await application.watchSubunit(
+      created,
+      'the-expanse',
+      's1e1',
+    );
+    expect(withFirstEpisode.items[0]).toMatchObject({
+      status: 'in_progress',
+      progress: { current: 1, target: 2, unit: 'subunits' },
+    });
+
+    const completed = await application.watchSubunit(
+      withFirstEpisode,
+      'the-expanse',
+      's1e2',
+    );
+    expect(completed.items[0]).toMatchObject({
+      status: 'completed',
+      progress: { current: 2, target: 2, unit: 'subunits' },
+    });
+    expect(completed.history.map((entry) => entry.action)).toEqual([
+      'created',
+      'watched',
+      'watched',
+      'completed',
+    ]);
+
+    const reopened = await application.reopenTrackedItem(
+      completed,
+      'the-expanse',
+    );
+    expect(reopened.items[0]).toMatchObject({
+      status: 'in_progress',
+      progress: { current: 0, target: 2, unit: 'subunits' },
+    });
+    expect(reopened.items[0].subunits).toMatchObject([
+      { id: 'season-1', completed: false, watchCount: 0 },
+      { id: 's1e1', completed: false, watchCount: 1 },
+      { id: 's1e2', completed: false, watchCount: 1 },
+    ]);
+
+    const rewatched = await application.watchSubunit(
+      reopened,
+      'the-expanse',
+      's1e1',
+    );
+    const watches = rewatched.history.filter(
+      (entry) => entry.subunitId === 's1e1',
+    );
+    expect(watches).toMatchObject([
+      { action: 'watched', subunitId: 's1e1' },
+      { action: 'rewatched', subunitId: 's1e1' },
+    ]);
+    expect(watches[0].id).not.toBe(watches[1].id);
+    expect(
+      rewatched.items[0].subunits.find((unit) => unit.id === 's1e1'),
+    ).toMatchObject({ completed: true, watchCount: 2 });
+  });
+
+  it('normalizes contradictory imported parent state from valid leaf state', () => {
+    const archive = createEmptyArchive();
+    archive.items.push(createItem(seriesInput));
+
+    const normalized = parseArchiveSnapshot(archive);
+
+    expect(normalized.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(normalized.items[0]).toMatchObject({
+      status: 'planned',
+      progress: { current: 0, target: 2, unit: 'subunits' },
+    });
+  });
+
+  it('rejects malformed tracking hierarchies at the archive boundary', () => {
+    const archive = createEmptyArchive();
+    archive.items.push(
+      createItem({
+        ...seriesInput,
+        subunits: [
+          {
+            id: 'episode-1',
+            kind: 'episode',
+            title: 'Episode 1',
+            parentId: 'missing-season',
+            completed: false,
+            watchCount: 0,
+          },
+        ],
+      }),
+    );
+
+    expect(() => parseArchiveSnapshot(archive)).toThrow(
+      'references a missing parent',
+    );
+  });
+});

--- a/web/app/app-shell/page.tsx
+++ b/web/app/app-shell/page.tsx
@@ -28,8 +28,18 @@ import {
 } from '../../../src/domain/archive';
 import { filterItems, getHistoryTimeline } from '../../../src/domain/search';
 
-type Episode = { number: number; title: string };
-type SeriesSeason = { number: number; title: string; episodes: Episode[] };
+type Episode = {
+  id: string;
+  number: number;
+  title: string;
+  completed: boolean;
+};
+type SeriesSeason = {
+  id: string;
+  number: number;
+  title: string;
+  episodes: Episode[];
+};
 type EpisodeSelection = { seasonNumber: number; episodeNumber: number };
 type ItemForm = {
   title: string;
@@ -139,6 +149,32 @@ const stringAttribute = (item: Item, key: string): string | undefined => {
   return typeof value === 'string' ? value : undefined;
 };
 
+const orderedByPosition = <T extends { position?: number }>(items: T[]): T[] =>
+  [...items].sort(
+    (left, right) =>
+      (left.position ?? Number.MAX_SAFE_INTEGER) -
+      (right.position ?? Number.MAX_SAFE_INTEGER),
+  );
+
+const toSeriesSeasons = (item: Item): SeriesSeason[] =>
+  orderedByPosition(item.subunits.filter((unit) => unit.kind === 'season')).map(
+    (season, index) => ({
+      id: season.id,
+      number: season.position ?? index + 1,
+      title: season.title,
+      episodes: orderedByPosition(
+        item.subunits.filter(
+          (unit) => unit.parentId === season.id && unit.kind === 'episode',
+        ),
+      ).map((episode, episodeIndex) => ({
+        id: episode.id,
+        number: episode.position ?? episodeIndex + 1,
+        title: episode.title,
+        completed: episode.completed,
+      })),
+    }),
+  );
+
 const toTrackedItem = (
   item: Item,
   defaultPlaceholderCover: boolean,
@@ -172,6 +208,7 @@ const toTrackedItem = (
     description: item.description ?? '',
     tags: item.tags,
     rating: item.rating,
+    seasons: item.category === 'Series' ? toSeriesSeasons(item) : undefined,
   };
 };
 
@@ -227,9 +264,6 @@ export default function AppShellPage() {
   const [detailView, setDetailView] = useState<'summary' | 'expanded'>(
     'summary',
   );
-  const [completedEpisodesByItem, setCompletedEpisodesByItem] = useState<
-    Record<string, Record<string, boolean>>
-  >({});
   const [selectedEpisode, setSelectedEpisode] =
     useState<EpisodeSelection | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
@@ -360,19 +394,7 @@ export default function AppShellPage() {
     };
   }, [themeMode]);
 
-  const getItemProgress = (item: TrackedItem) => {
-    if (item.category !== 'Series' || !item.seasons?.length) {
-      return item.value;
-    }
-
-    const episodes = item.seasons.flatMap((season) =>
-      season.episodes.map((episode) => `${season.number}-${episode.number}`),
-    );
-    const completed = episodes.filter(
-      (key) => completedEpisodesByItem[item.id]?.[key],
-    ).length;
-    return episodes.length > 0 ? (completed / episodes.length) * 100 : 0;
-  };
+  const getItemProgress = (item: TrackedItem) => item.value;
 
   const items = useMemo(
     () =>
@@ -406,10 +428,7 @@ export default function AppShellPage() {
       })()
     : null;
   const selectedCompletedEpisodes = selectedEpisodes.filter(
-    (episode) =>
-      completedEpisodesByItem[selectedItem.id]?.[
-        `${episode.seasonNumber}-${episode.number}`
-      ],
+    (episode) => episode.completed,
   ).length;
   const selectedProgress = getItemProgress(selectedItem);
   const selectedProgressPercent = Math.round(selectedProgress);
@@ -574,7 +593,6 @@ export default function AppShellPage() {
       setSelectedId(null);
       setDetailView('summary');
       setSelectedEpisode(null);
-      setCompletedEpisodesByItem({});
       setOperationError(null);
       setBackupStatus(
         `Restored ${restored.items.length} ${restored.items.length === 1 ? 'item' : 'items'} from ${file.name}.`,
@@ -588,18 +606,24 @@ export default function AppShellPage() {
     }
   };
 
-  const toggleEpisodeCompletion = (
-    seasonNumber: number,
-    episodeNumber: number,
-  ) => {
-    const key = `${seasonNumber}-${episodeNumber}`;
-    setCompletedEpisodesByItem((state) => ({
-      ...state,
-      [selectedItem.id]: {
-        ...state[selectedItem.id],
-        [key]: !state[selectedItem.id]?.[key],
-      },
-    }));
+  const recordEpisodeWatch = async (episodeId: string) => {
+    if (!archive || !application.current || !selectedDomainItem) return;
+
+    try {
+      setArchive(
+        await application.current.watchSubunit(
+          archive,
+          selectedDomainItem.id,
+          episodeId,
+        ),
+      );
+    } catch (error) {
+      setOperationError(
+        error instanceof Error
+          ? error.message
+          : 'Could not record this episode watch',
+      );
+    }
   };
 
   const visibleItems = useMemo(() => {
@@ -1906,10 +1930,7 @@ export default function AppShellPage() {
                         {
                           selectedSeasons.filter((season) =>
                             season.episodes.every(
-                              (episode) =>
-                                completedEpisodesByItem[selectedItem.id]?.[
-                                  `${season.number}-${episode.number}`
-                                ],
+                              (episode) => episode.completed,
                             ),
                           ).length
                         }{' '}
@@ -1919,10 +1940,7 @@ export default function AppShellPage() {
                     <div className="season-list">
                       {selectedSeasons.map((season) => {
                         const completedCount = season.episodes.filter(
-                          (episode) =>
-                            completedEpisodesByItem[selectedItem.id]?.[
-                              `${season.number}-${episode.number}`
-                            ],
+                          (episode) => episode.completed,
                         ).length;
                         const isComplete =
                           completedCount === season.episodes.length;
@@ -1945,11 +1963,7 @@ export default function AppShellPage() {
                             </div>
                             <div className="episode-list">
                               {season.episodes.map((episode) => {
-                                const isComplete = Boolean(
-                                  completedEpisodesByItem[selectedItem.id]?.[
-                                    `${season.number}-${episode.number}`
-                                  ],
-                                );
+                                const isComplete = episode.completed;
                                 return (
                                   <div
                                     key={episode.number}
@@ -1988,15 +2002,12 @@ export default function AppShellPage() {
                                     <button
                                       type="button"
                                       className="episode-card-state"
-                                      aria-label={`${isComplete ? 'Mark as unwatched' : 'Mark as watched'}: ${season.title}, episode ${episode.number}`}
+                                      aria-label={`${isComplete ? 'Rewatch' : 'Mark as watched'}: ${season.title}, episode ${episode.number}`}
                                       onClick={() =>
-                                        toggleEpisodeCompletion(
-                                          season.number,
-                                          episode.number,
-                                        )
+                                        void recordEpisodeWatch(episode.id)
                                       }
                                     >
-                                      {isComplete ? '✓' : '+'}
+                                      {isComplete ? '↻' : '+'}
                                     </button>
                                   </div>
                                 );
@@ -2127,11 +2138,9 @@ export default function AppShellPage() {
                   {selectedEpisodeDetail.episode.title}
                 </h2>
                 <span
-                  className={`episode-detail-status ${completedEpisodesByItem[selectedItem.id]?.[`${selectedEpisodeDetail.season.number}-${selectedEpisodeDetail.episode.number}`] ? 'is-complete' : ''}`}
+                  className={`episode-detail-status ${selectedEpisodeDetail.episode.completed ? 'is-complete' : ''}`}
                 >
-                  {completedEpisodesByItem[selectedItem.id]?.[
-                    `${selectedEpisodeDetail.season.number}-${selectedEpisodeDetail.episode.number}`
-                  ]
+                  {selectedEpisodeDetail.episode.completed
                     ? 'Watched'
                     : 'Not watched'}
                 </span>
@@ -2162,16 +2171,11 @@ export default function AppShellPage() {
                   type="button"
                   className="primary-btn"
                   onClick={() =>
-                    toggleEpisodeCompletion(
-                      selectedEpisodeDetail.season.number,
-                      selectedEpisodeDetail.episode.number,
-                    )
+                    void recordEpisodeWatch(selectedEpisodeDetail.episode.id)
                   }
                 >
-                  {completedEpisodesByItem[selectedItem.id]?.[
-                    `${selectedEpisodeDetail.season.number}-${selectedEpisodeDetail.episode.number}`
-                  ]
-                    ? 'Mark as unwatched'
+                  {selectedEpisodeDetail.episode.completed
+                    ? 'Rewatch episode'
                     : 'Mark as watched'}
                 </button>
               </div>


### PR DESCRIPTION
## What

Close #48

- Added persisted, generic parent/sub-unit tracking to `ArchiveSnapshot`.
- Added derived parent progress and status from leaf sub-units.
- Added explicit watch, rewatch, and reopen application operations with independent history entries.
- Updated the app shell to read episode completion from the persisted archive rather than React-only state.
- Introduced archive schema version 2, migration from version 1, documentation, and RFC 0003.

## Why

Sequential media can otherwise store contradictory states: for example, a series marked completed while episodes remain incomplete, or a rewatch overwriting the original watch history.

This change makes child units the source of truth for hierarchical tracking, preserves each watch/rewatch event, and keeps parent progress consistent across persistence, backup, and restore.

## How

- Added a generic `subunits` hierarchy to items, supporting seasons, episodes, chapters, and future unit types.
- Only leaf units persist current-cycle `completed` state and all-time `watchCount`; container units derive their state from descendants.
- Parent progress is calculated from completed leaves. A parent is completed only when every leaf is completed.
- Reopening clears current-cycle leaf completion while preserving historical watch counts and history entries.
- Added `watched`, `rewatched`, and `reopened` history actions, with optional `subunitId`.
- Archive parsing validates duplicate IDs, missing parents, cycles, and invalid completion state on container units. Valid imported parent state is normalized from children.
- Migrated schema version 1 archives to version 2 with an empty `subunits` list, retaining existing manual progress.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test` — 29 tests passed
- `npm run build --prefix web`
- `git diff --check`

Regression coverage includes:

- parent progress and completion derived from episode leaves;
- completed parent reopening;
- preserved watch counts after reopening;
- distinct watch and rewatch history entries;
- normalization of contradictory imported parent state;
- rejection of malformed parent/sub-unit hierarchies;
- migration of schema version 1 archives.

## Data impact

Yes. This changes the portable archive format from schema version 1 to version 2.

Items may now contain persisted `subunits`; history entries may reference a `subunitId` and use `watched`, `rewatched`, or `reopened` actions. Existing version 1 archives migrate safely with no sub-units and retain their manual progress.

Malformed or unsupported archives are rejected before they are persisted or restored. Invalid hierarchies do not replace existing local data; valid hierarchies with contradictory parent progress or status are normalized from their leaf units.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed
- [x] Accessibility considered for UI/interaction changes
- [x] No unrelated refactors bundled into this PR