### PR TITLE
feat: implement offline delivery support with service worker and upda…

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -63,4 +63,4 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Test backup and restore flow in Chromium
-        run: npm run test:e2e
+        run: npx playwright test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.0.0/
 
 ### Added
 
+- Offline delivery for the production web app after its first successful visit, without caching user archive data.
 - Persisted parent/sub-unit tracking with derived parent progress, reopening, and independent watch/rewatch history entries.
 - Complete browser-local JSON backup export and restore, with validation and migration before local data is replaced.
 - Automated linting and formatting checks for contributions and pull requests, with staged-file checks before each commit.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ npm test
 npm run test:e2e
 ```
 
-The end-to-end suite starts the web app and runs the backup-and-restore
-recovery flow in Chromium. Install its browser binary once with
+The end-to-end suite builds the production web app, then runs recovery and
+offline delivery flows in Chromium. Install its browser binary once with
 `npx playwright install chromium` before running it locally.
 
 ### Web app
@@ -149,7 +149,11 @@ Everyone is welcome to join, whether you want to triage, pick up an issue, or ju
 
 Early-stage.
 
-The web app provides browser-local tracking, complete JSON backup export, and validated JSON restore. The optional network layer remains under active development; see the [Product Requirements](docs/PRODUCT_REQUIREMENTS.md) and [Roadmap](ROADMAP.md) for the planned scope.
+The web app provides browser-local tracking, complete JSON backup export,
+validated JSON restore, and offline opening after a successful first visit.
+The optional network layer remains under active development; see the [Product
+Requirements](docs/PRODUCT_REQUIREMENTS.md) and [Roadmap](ROADMAP.md) for the
+planned scope.
 
 The first milestone is intentionally small: prove that a user can create data locally, close the app, reopen it, export everything, delete the local state, restore the backup, and recover the same information.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,11 @@ leaf units. `ArchiveApplication` records watches, rewatches, and reopening as
 separate history entries; React must not maintain an independent source of
 episode completion state.
 
+The production web app also has a narrowly scoped service worker for offline
+delivery. It caches only the app shell and required same-origin static assets;
+it never caches or mediates the IndexedDB archive, backup files, or user-owned
+state. See [Offline web delivery](OFFLINE.md) for behavior and limitations.
+
 ## Generic item model
 
 Avoid tables and domain logic tied to a single media category.

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -1,0 +1,37 @@
+# Offline web delivery
+
+## Scope
+
+The production web app registers a service worker after the first successful
+visit. It caches the app shell and same-origin scripts, styles, fonts, and
+images required by the current page. Once cached, `/app-shell` can open without
+a network connection.
+
+The service worker is intentionally not enabled during local development. Run
+a production build to verify offline behavior.
+
+## Local data
+
+The service worker never caches IndexedDB records, backup files, form input, or
+any other user-owned archive data. The existing browser archive store remains
+the only persistence implementation for items, history, preferences, and
+collections.
+
+After the app shell is available offline, local create, edit, search, export,
+and restore operations continue to use that browser-local archive. They do not
+need an account, a provider, telemetry, cloud sync, or a network request.
+
+## Limitations
+
+- Offline delivery starts only after a successful online visit and service
+  worker registration.
+- New deployments are fetched on the next online navigation; offline users see
+  their last cached app shell until they reconnect.
+- Remote catalog, provider, and optional network functionality is not cached or
+  made available offline.
+
+## Verification
+
+`npm run test:e2e` uses a production build and verifies that the app opens,
+creates an item, searches, exports, clears local state, and restores a backup
+while the browser context is offline.

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -22,8 +22,8 @@ and restore operations continue to use that browser-local archive. They do not
 need an account, a provider, telemetry, cloud sync, or a network request.
 
 When the browser is offline, the app displays a dismissible status message. If
-the message is dismissed, a compact top-bar reminder remains available and can
-be opened again; it is cleared when connectivity returns.
+the message is dismissed, a compact reminder remains above the Local sync card
+on desktop and can be opened again; it is cleared when connectivity returns.
 
 ## Limitations
 

--- a/docs/OFFLINE.md
+++ b/docs/OFFLINE.md
@@ -21,6 +21,10 @@ After the app shell is available offline, local create, edit, search, export,
 and restore operations continue to use that browser-local archive. They do not
 need an account, a provider, telemetry, cloud sync, or a network request.
 
+When the browser is offline, the app displays a dismissible status message. If
+the message is dismissed, a compact top-bar reminder remains available and can
+be opened again; it is cleared when connectivity returns.
+
 ## Limitations
 
 - Offline delivery starts only after a successful online visit and service

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -184,6 +184,9 @@ test('opens and restores local data while offline after its first visit', async 
   try {
     await page.reload();
     await expect(page.getByRole('button', { name: 'New item' })).toBeVisible();
+    await expect(page.getByRole('status')).toHaveText(
+      /You're offline.*Your library, changes, backups, and restores stay available on this device\./,
+    );
     await addItem(page, 'Offline archive item');
     await openItemDetail(page, 'Offline archive item');
     await page
@@ -218,7 +221,7 @@ test('opens and restores local data while offline after its first visit', async 
     await openManagePage(page, 'Import');
     page.once('dialog', (dialog) => dialog.accept());
     await page.locator('input[type="file"]').setInputFiles(backupPath);
-    await expect(page.getByRole('status')).toHaveText(
+    await expect(page.getByText(/^Restored 1 item from /)).toHaveText(
       /^Restored 1 item from open-personal-tracking-backup-.*\.json\.$/,
     );
     await page

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -245,6 +245,8 @@ test('opens and restores local data while offline after its first visit', async 
       .click();
     await expect(itemInList(page, 'Offline archive item')).toBeVisible();
   } finally {
-    await page.context().setOffline(false);
+    if (!page.isClosed()) {
+      await page.context().setOffline(false);
+    }
   }
 });

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -187,6 +187,11 @@ test('opens and restores local data while offline after its first visit', async 
     await expect(page.getByRole('status')).toHaveText(
       /You're offline.*Your library, changes, backups, and restores stay available on this device\./,
     );
+    await page.getByRole('button', { name: 'Dismiss offline message' }).click();
+    await expect(
+      page.getByRole('button', { name: 'Show offline details' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Show offline details' }).click();
     await addItem(page, 'Offline archive item');
     await openItemDetail(page, 'Offline archive item');
     await page

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -191,6 +191,15 @@ test('opens and restores local data while offline after its first visit', async 
     await expect(
       page.getByRole('button', { name: 'Show offline details' }),
     ).toBeVisible();
+    const [offlineReminderBox, localSyncLabelBox] = await Promise.all([
+      page.getByRole('button', { name: 'Show offline details' }).boundingBox(),
+      page.getByText('Local sync', { exact: true }).boundingBox(),
+    ]);
+    expect(offlineReminderBox).not.toBeNull();
+    expect(localSyncLabelBox).not.toBeNull();
+    expect(
+      offlineReminderBox!.y + offlineReminderBox!.height,
+    ).toBeLessThanOrEqual(localSyncLabelBox!.y);
     await page.getByRole('button', { name: 'Show offline details' }).click();
     await addItem(page, 'Offline archive item');
     await openItemDetail(page, 'Offline archive item');

--- a/e2e/backup-restore.spec.ts
+++ b/e2e/backup-restore.spec.ts
@@ -68,6 +68,18 @@ const openManagePage = (page: Page, name: 'Export' | 'Import') =>
     .getByRole('button', { name, exact: true })
     .click();
 
+const activateOfflineSupport = async (page: Page): Promise<void> => {
+  await page.evaluate(() => navigator.serviceWorker.ready);
+  await page.reload();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => navigator.serviceWorker.controller?.state === 'activated',
+      ),
+    )
+    .toBe(true);
+};
+
 test.beforeEach(async ({ page }) => {
   await completeOnboarding(page);
   await page.goto(APP_PATH);
@@ -161,4 +173,61 @@ test('keeps the existing archive when a backup file is invalid', async ({
     .first()
     .click();
   await expect(itemInList(page, 'Existing archive item')).toBeVisible();
+});
+
+test('opens and restores local data while offline after its first visit', async ({
+  page,
+}, testInfo) => {
+  await activateOfflineSupport(page);
+  await page.context().setOffline(true);
+
+  try {
+    await page.reload();
+    await expect(page.getByRole('button', { name: 'New item' })).toBeVisible();
+    await addItem(page, 'Offline archive item');
+    await openItemDetail(page, 'Offline archive item');
+    await page
+      .getByRole('complementary', { name: 'Selected item details' })
+      .getByRole('button', { name: 'Edit' })
+      .click();
+    await page
+      .getByRole('dialog', { name: 'New item' })
+      .getByLabel('Description')
+      .fill('Updated without a network connection.');
+    await page
+      .getByRole('dialog', { name: 'New item' })
+      .getByRole('button', { name: 'Save item' })
+      .click();
+    await page
+      .getByLabel('Search your library')
+      .first()
+      .fill('Offline archive item');
+    await expect(itemInList(page, 'Offline archive item')).toBeVisible();
+
+    await openManagePage(page, 'Export');
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export now' }).click();
+    const download = await downloadPromise;
+    const backupPath = testInfo.outputPath(download.suggestedFilename());
+    await download.saveAs(backupPath);
+
+    await clearArchive(page);
+    await page.reload();
+    await expect(page.getByText('Nothing tracked yet')).toBeVisible();
+
+    await openManagePage(page, 'Import');
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.locator('input[type="file"]').setInputFiles(backupPath);
+    await expect(page.getByRole('status')).toHaveText(
+      /^Restored 1 item from open-personal-tracking-backup-.*\.json\.$/,
+    );
+    await page
+      .getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('button', { name: /^Library/ })
+      .first()
+      .click();
+    await expect(itemInList(page, 'Offline archive item')).toBeVisible();
+  } finally {
+    await page.context().setOffline(false);
+  }
 });

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     "build": "tsc --noEmit",
     "lint": "eslint src tests e2e playwright.config.ts --max-warnings=0",
-    "format": "prettier --write .github scripts src tests e2e web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
-    "format:check": "prettier --check .github scripts src tests e2e web/app package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
+    "format": "prettier --write .github scripts src tests e2e web/app web/public/service-worker.js package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
+    "format:check": "prettier --check .github scripts src tests e2e web/app web/public/service-worker.js package.json web/package.json tsconfig.json web/tsconfig.json vitest.config.ts playwright.config.ts web/next.config.mjs .eslintrc.cjs web/.eslintrc.json .prettierrc.json lint-staged.config.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test",
+    "test:e2e": "npm run build --prefix web && playwright test",
     "prepare": "husky"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const isCI = Boolean(process.env.CI);
+const webServerPort = Number(process.env.PLAYWRIGHT_WEB_SERVER_PORT ?? 3100);
+const webServerUrl = `http://127.0.0.1:${webServerPort}`;
 
 export default defineConfig({
   testDir: './e2e',
@@ -10,7 +12,7 @@ export default defineConfig({
   workers: isCI ? 1 : undefined,
   reporter: isCI ? 'github' : 'list',
   use: {
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL: webServerUrl,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -22,8 +24,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run start --prefix web -- --hostname 127.0.0.1',
-    url: 'http://127.0.0.1:3000/app-shell',
+    command: `npm run start --prefix web -- --hostname 127.0.0.1 --port ${webServerPort}`,
+    url: `${webServerUrl}/app-shell`,
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,9 +22,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev --prefix web -- --hostname 127.0.0.1',
+    command: 'npm run start --prefix web -- --hostname 127.0.0.1',
     url: 'http://127.0.0.1:3000/app-shell',
-    reuseExistingServer: !isCI,
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/web/app/app-shell/page.tsx
+++ b/web/app/app-shell/page.tsx
@@ -728,7 +728,7 @@ export default function AppShellPage() {
       className="app-shell"
       aria-label="Open personal tracking application shell"
     >
-      <ConnectionStatus />
+      <ConnectionStatus placement="mobile" />
       <aside className="sidebar" aria-label="Navigation sidebar">
         <a
           href="#"
@@ -856,13 +856,16 @@ export default function AppShellPage() {
           </button>
         </nav>
 
-        <div className="sidebar-meta" aria-live="polite">
-          <div className="status-block">
-            <span>Local sync</span>
-            <span className="status-dot" aria-label="Connected locally" />
+        <div className="sidebar-footer">
+          <ConnectionStatus placement="desktop" />
+          <div className="sidebar-meta" aria-live="polite">
+            <div className="status-block">
+              <span>Local sync</span>
+              <span className="status-dot" aria-label="Connected locally" />
+            </div>
+            <strong>Local archive</strong>
+            <div>{items.length} items stored on this device</div>
           </div>
-          <strong>Local archive</strong>
-          <div>{items.length} items stored on this device</div>
         </div>
       </aside>
 

--- a/web/app/app-shell/page.tsx
+++ b/web/app/app-shell/page.tsx
@@ -27,6 +27,7 @@ import {
   type UserPreferences,
 } from '../../../src/domain/archive';
 import { filterItems, getHistoryTimeline } from '../../../src/domain/search';
+import { ConnectionStatus } from '../connection-status';
 
 type Episode = {
   id: string;
@@ -727,6 +728,7 @@ export default function AppShellPage() {
       className="app-shell"
       aria-label="Open personal tracking application shell"
     >
+      <ConnectionStatus />
       <aside className="sidebar" aria-label="Navigation sidebar">
         <a
           href="#"

--- a/web/app/connection-status.tsx
+++ b/web/app/connection-status.tsx
@@ -4,13 +4,18 @@ import { Wifi, WifiOff, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 type ConnectionState = 'offline' | 'online' | null;
+type ConnectionStatusPlacement = 'desktop' | 'mobile';
 
 const RECONNECTED_MESSAGE_DURATION_MS = 4_000;
 const OFFLINE_MESSAGE_DISMISSED_KEY =
   'open-personal-tracking.offline-message-dismissed';
 
 /** Announces browser connectivity without changing local archive behavior. */
-export const ConnectionStatus = () => {
+export const ConnectionStatus = ({
+  placement,
+}: {
+  placement: ConnectionStatusPlacement;
+}) => {
   const [connectionState, setConnectionState] = useState<ConnectionState>(null);
   const [isOfflineMessageDismissed, setIsOfflineMessageDismissed] =
     useState(false);
@@ -66,7 +71,9 @@ export const ConnectionStatus = () => {
 
   if (isOffline && isOfflineMessageDismissed) {
     return (
-      <div className="connection-status connection-status--compact">
+      <div
+        className={`connection-status connection-status--${placement} connection-status--compact`}
+      >
         <button
           type="button"
           onClick={showOfflineMessage}
@@ -81,7 +88,7 @@ export const ConnectionStatus = () => {
 
   return (
     <div
-      className={`connection-status connection-status--expanded ${isOffline ? 'is-offline' : 'is-online'}`}
+      className={`connection-status connection-status--${placement} connection-status--expanded ${isOffline ? 'is-offline' : 'is-online'}`}
       role="status"
       aria-live="polite"
     >

--- a/web/app/connection-status.tsx
+++ b/web/app/connection-status.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import { Wifi, WifiOff } from 'lucide-react';
+import { Wifi, WifiOff, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 type ConnectionState = 'offline' | 'online' | null;
 
 const RECONNECTED_MESSAGE_DURATION_MS = 4_000;
+const OFFLINE_MESSAGE_DISMISSED_KEY =
+  'open-personal-tracking.offline-message-dismissed';
 
 /** Announces browser connectivity without changing local archive behavior. */
 export const ConnectionStatus = () => {
   const [connectionState, setConnectionState] = useState<ConnectionState>(null);
+  const [isOfflineMessageDismissed, setIsOfflineMessageDismissed] =
+    useState(false);
 
   useEffect(() => {
     let clearReconnectedMessage: number | undefined;
@@ -18,9 +22,14 @@ export const ConnectionStatus = () => {
       if (clearReconnectedMessage) {
         window.clearTimeout(clearReconnectedMessage);
       }
+      setIsOfflineMessageDismissed(
+        window.sessionStorage.getItem(OFFLINE_MESSAGE_DISMISSED_KEY) === 'true',
+      );
       setConnectionState('offline');
     };
     const showOnline = () => {
+      window.sessionStorage.removeItem(OFFLINE_MESSAGE_DISMISSED_KEY);
+      setIsOfflineMessageDismissed(false);
       setConnectionState('online');
       clearReconnectedMessage = window.setTimeout(
         () => setConnectionState(null),
@@ -41,13 +50,38 @@ export const ConnectionStatus = () => {
     };
   }, []);
 
+  const dismissOfflineMessage = () => {
+    window.sessionStorage.setItem(OFFLINE_MESSAGE_DISMISSED_KEY, 'true');
+    setIsOfflineMessageDismissed(true);
+  };
+
+  const showOfflineMessage = () => {
+    window.sessionStorage.removeItem(OFFLINE_MESSAGE_DISMISSED_KEY);
+    setIsOfflineMessageDismissed(false);
+  };
+
   if (!connectionState) return null;
 
   const isOffline = connectionState === 'offline';
 
+  if (isOffline && isOfflineMessageDismissed) {
+    return (
+      <div className="connection-status connection-status--compact">
+        <button
+          type="button"
+          onClick={showOfflineMessage}
+          aria-label="Show offline details"
+        >
+          <WifiOff aria-hidden="true" />
+          <span>Offline · working locally</span>
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div
-      className={`connection-status ${isOffline ? 'is-offline' : 'is-online'}`}
+      className={`connection-status connection-status--expanded ${isOffline ? 'is-offline' : 'is-online'}`}
       role="status"
       aria-live="polite"
     >
@@ -60,6 +94,16 @@ export const ConnectionStatus = () => {
             : 'Your local library was not changed.'}
         </span>
       </div>
+      {isOffline && (
+        <button
+          className="connection-status-dismiss"
+          type="button"
+          onClick={dismissOfflineMessage}
+          aria-label="Dismiss offline message"
+        >
+          <X aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 };

--- a/web/app/connection-status.tsx
+++ b/web/app/connection-status.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Wifi, WifiOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+type ConnectionState = 'offline' | 'online' | null;
+
+const RECONNECTED_MESSAGE_DURATION_MS = 4_000;
+
+/** Announces browser connectivity without changing local archive behavior. */
+export const ConnectionStatus = () => {
+  const [connectionState, setConnectionState] = useState<ConnectionState>(null);
+
+  useEffect(() => {
+    let clearReconnectedMessage: number | undefined;
+
+    const showOffline = () => {
+      if (clearReconnectedMessage) {
+        window.clearTimeout(clearReconnectedMessage);
+      }
+      setConnectionState('offline');
+    };
+    const showOnline = () => {
+      setConnectionState('online');
+      clearReconnectedMessage = window.setTimeout(
+        () => setConnectionState(null),
+        RECONNECTED_MESSAGE_DURATION_MS,
+      );
+    };
+
+    if (!navigator.onLine) showOffline();
+    window.addEventListener('offline', showOffline);
+    window.addEventListener('online', showOnline);
+
+    return () => {
+      if (clearReconnectedMessage) {
+        window.clearTimeout(clearReconnectedMessage);
+      }
+      window.removeEventListener('offline', showOffline);
+      window.removeEventListener('online', showOnline);
+    };
+  }, []);
+
+  if (!connectionState) return null;
+
+  const isOffline = connectionState === 'offline';
+
+  return (
+    <div
+      className={`connection-status ${isOffline ? 'is-offline' : 'is-online'}`}
+      role="status"
+      aria-live="polite"
+    >
+      {isOffline ? <WifiOff aria-hidden="true" /> : <Wifi aria-hidden="true" />}
+      <div>
+        <strong>{isOffline ? "You're offline" : "You're back online"}</strong>
+        <span>
+          {isOffline
+            ? 'Your library, changes, backups, and restores stay available on this device.'
+            : 'Your local library was not changed.'}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -96,19 +96,47 @@ body {
 .connection-status {
   position: fixed;
   z-index: 100;
-  top: max(0.75rem, env(safe-area-inset-top));
   left: 50%;
   display: flex;
   align-items: flex-start;
   gap: 0.7rem;
-  width: min(calc(100% - 2rem), 38rem);
-  padding: 0.75rem 0.9rem;
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-xs);
   background: var(--surface-strong);
   box-shadow: var(--panel-shadow);
   color: var(--ink);
   transform: translateX(-50%);
+}
+
+.connection-status--expanded {
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  width: min(calc(100% - 2rem), 38rem);
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-xs);
+}
+
+.connection-status--compact {
+  top: 0;
+  border-top: 0;
+  border-radius: 0 0 var(--radius-xs) var(--radius-xs);
+}
+
+.connection-status--compact button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.7rem;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+.connection-status--compact button:focus-visible,
+.connection-status-dismiss:focus-visible {
+  outline: 2px solid var(--brass-strong);
+  outline-offset: 2px;
 }
 
 .connection-status.is-offline {
@@ -126,6 +154,13 @@ body {
   margin-top: 0.1rem;
 }
 
+.connection-status--compact svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  margin: 0;
+  color: var(--stamp);
+}
+
 .connection-status.is-offline svg {
   color: var(--stamp);
 }
@@ -137,6 +172,29 @@ body {
 .connection-status strong,
 .connection-status span {
   display: block;
+}
+
+.connection-status-dismiss {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  margin: -0.25rem -0.35rem -0.25rem auto;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+}
+
+.connection-status-dismiss:hover {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+
+.connection-status-dismiss svg {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
 }
 
 .connection-status strong {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -93,6 +93,63 @@ body {
   padding: 0;
 }
 
+.connection-status {
+  position: fixed;
+  z-index: 100;
+  top: max(0.75rem, env(safe-area-inset-top));
+  left: 50%;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  width: min(calc(100% - 2rem), 38rem);
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xs);
+  background: var(--surface-strong);
+  box-shadow: var(--panel-shadow);
+  color: var(--ink);
+  transform: translateX(-50%);
+}
+
+.connection-status.is-offline {
+  border-color: color-mix(in srgb, var(--stamp) 60%, var(--hairline));
+}
+
+.connection-status.is-online {
+  border-color: color-mix(in srgb, var(--success) 60%, var(--hairline));
+}
+
+.connection-status svg {
+  flex: 0 0 auto;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin-top: 0.1rem;
+}
+
+.connection-status.is-offline svg {
+  color: var(--stamp);
+}
+
+.connection-status.is-online svg {
+  color: var(--success);
+}
+
+.connection-status strong,
+.connection-status span {
+  display: block;
+}
+
+.connection-status strong {
+  font-size: 0.9rem;
+}
+
+.connection-status span {
+  margin-top: 0.05rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 a {
   color: inherit;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -95,7 +95,7 @@ body {
 
 .connection-status {
   position: fixed;
-  z-index: 100;
+  z-index: 20;
   display: flex;
   align-items: flex-start;
   gap: 0.7rem;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -96,7 +96,6 @@ body {
 .connection-status {
   position: fixed;
   z-index: 100;
-  left: 50%;
   display: flex;
   align-items: flex-start;
   gap: 0.7rem;
@@ -104,33 +103,37 @@ body {
   background: var(--surface-strong);
   box-shadow: var(--panel-shadow);
   color: var(--ink);
-  transform: translateX(-50%);
 }
 
 .connection-status--expanded {
+  right: max(1rem, env(safe-area-inset-right));
   bottom: max(1rem, env(safe-area-inset-bottom));
-  width: min(calc(100% - 2rem), 38rem);
+  width: min(calc(100% - 2rem), 30rem);
   padding: 0.75rem 0.9rem;
   border-radius: var(--radius-xs);
 }
 
 .connection-status--compact {
-  top: 0;
-  border-top: 0;
-  border-radius: 0 0 var(--radius-xs) var(--radius-xs);
+  left: 18px;
+  bottom: 132px;
+  width: calc(260px - 36px);
+  border-radius: 16px;
+  box-shadow: none;
 }
 
 .connection-status--compact button {
   display: inline-flex;
   align-items: center;
+  width: 100%;
   gap: 0.4rem;
   min-height: 2rem;
-  padding: 0.35rem 0.7rem;
+  padding: 0.65rem 0.7rem;
   border: 0;
   background: transparent;
   color: var(--ink);
   font-family: var(--font-mono);
   font-size: 0.7rem;
+  text-align: left;
 }
 
 .connection-status--compact button:focus-visible,
@@ -206,6 +209,25 @@ body {
   color: var(--muted);
   font-size: 0.8rem;
   line-height: 1.4;
+}
+
+@media (max-width: 960px) and (min-width: 901px) {
+  .connection-status--compact {
+    width: calc(220px - 36px);
+  }
+}
+
+@media (max-width: 900px) {
+  .connection-status--expanded {
+    bottom: max(5.5rem, calc(1rem + env(safe-area-inset-bottom)));
+  }
+
+  .connection-status--compact {
+    right: 1rem;
+    bottom: max(5.5rem, calc(1rem + env(safe-area-inset-bottom)));
+    left: auto;
+    width: auto;
+  }
 }
 
 a {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -121,6 +121,15 @@ body {
   box-shadow: none;
 }
 
+.connection-status--desktop.connection-status--compact {
+  position: static;
+  width: auto;
+}
+
+.connection-status--mobile {
+  display: none;
+}
+
 .connection-status--compact button {
   display: inline-flex;
   align-items: center;
@@ -218,6 +227,14 @@ body {
 }
 
 @media (max-width: 900px) {
+  .connection-status--desktop {
+    display: none;
+  }
+
+  .connection-status--mobile {
+    display: flex;
+  }
+
   .connection-status--expanded {
     bottom: max(5.5rem, calc(1rem + env(safe-area-inset-bottom)));
   }
@@ -894,8 +911,13 @@ section.copy .muted {
   color: var(--muted);
 }
 
-.sidebar-meta {
+.sidebar-footer {
+  display: grid;
+  gap: 12px;
   margin-top: auto;
+}
+
+.sidebar-meta {
   background: var(--surface-strong);
   border: 1px solid var(--hairline);
   border-radius: 16px;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css';
 import type { Metadata } from 'next';
 import { Fraunces, IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google';
 
+import { OfflineSupport } from './offline-support';
+
 const fraunces = Fraunces({ subsets: ['latin'], variable: '--font-display' });
 const ibmSans = IBM_Plex_Sans({
   subsets: ['latin'],
@@ -40,7 +42,10 @@ export default function RootLayout({
       lang="en"
       className={`${fraunces.variable} ${ibmSans.variable} ${ibmMono.variable}`}
     >
-      <body>{children}</body>
+      <body>
+        <OfflineSupport />
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/app/offline-support.tsx
+++ b/web/app/offline-support.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SERVICE_WORKER_URL = '/service-worker.js';
+
+const getRequiredAssetUrls = (): string[] => {
+  const urls = new Set([window.location.href, '/app-shell']);
+  const assets = document.querySelectorAll<HTMLScriptElement | HTMLLinkElement>(
+    'script[src], link[rel="stylesheet"][href]',
+  );
+
+  for (const asset of Array.from(assets)) {
+    const assetUrl =
+      asset instanceof HTMLScriptElement ? asset.src : asset.href;
+    const url = new URL(assetUrl, window.location.href);
+    if (url.origin === window.location.origin) {
+      urls.add(url.href);
+    }
+  }
+
+  for (const resource of performance.getEntriesByType('resource')) {
+    const url = new URL(resource.name, window.location.href);
+    if (url.origin === window.location.origin) {
+      urls.add(url.href);
+    }
+  }
+
+  return Array.from(urls);
+};
+
+const cacheAppShellAssets = (
+  worker: ServiceWorker,
+  urls: string[],
+): Promise<void> =>
+  new Promise((resolve) => {
+    const channel = new MessageChannel();
+    const timeout = window.setTimeout(resolve, 5_000);
+    channel.port1.onmessage = () => {
+      window.clearTimeout(timeout);
+      resolve();
+    };
+    worker.postMessage({ type: 'CACHE_APP_SHELL_ASSETS', urls }, [
+      channel.port2,
+    ]);
+  });
+
+/** Registers offline delivery only for production builds of the web app. */
+export const OfflineSupport = () => {
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' ||
+      !('serviceWorker' in navigator)
+    ) {
+      return;
+    }
+
+    const register = async () => {
+      try {
+        await navigator.serviceWorker.register(SERVICE_WORKER_URL);
+        const registration = await navigator.serviceWorker.ready;
+        if (registration.active) {
+          await cacheAppShellAssets(
+            registration.active,
+            getRequiredAssetUrls(),
+          );
+        }
+      } catch {
+        // Offline delivery is progressive enhancement; normal online use stays available.
+      }
+    };
+
+    void register();
+  }, []);
+
+  return null;
+};

--- a/web/public/service-worker.js
+++ b/web/public/service-worker.js
@@ -1,0 +1,109 @@
+const CACHE_PREFIX = 'open-personal-tracking-shell-';
+const CACHE_NAME = `${CACHE_PREFIX}v1`;
+const APP_SHELL_URLS = ['/', '/app-shell'];
+
+const isCacheableResponse = (response) =>
+  response.ok && response.type === 'basic';
+
+const cacheResponse = async (request, response) => {
+  if (!isCacheableResponse(response)) return response;
+
+  const cache = await caches.open(CACHE_NAME);
+  await cache.put(request, response.clone());
+  return response;
+};
+
+const fetchAndCache = async (request) =>
+  cacheResponse(request, await fetch(request));
+
+const cacheUrls = async (urls) => {
+  await Promise.all(
+    urls.map(async (url) => {
+      try {
+        await fetchAndCache(new Request(url, { credentials: 'same-origin' }));
+      } catch {
+        // A missing optional asset must not prevent offline support installation.
+      }
+    }),
+  );
+};
+
+const handleNavigation = async (request) => {
+  try {
+    return await fetchAndCache(request);
+  } catch {
+    return (
+      (await caches.match(request)) ??
+      (await caches.match('/app-shell')) ??
+      new Response('The app is not available offline yet.', {
+        status: 503,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      })
+    );
+  }
+};
+
+const handleStaticAsset = async (request) => {
+  const cached = await caches.match(request);
+  return cached ?? fetchAndCache(request);
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(cacheUrls(APP_SHELL_URLS));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type !== 'CACHE_APP_SHELL_ASSETS') return;
+
+  const urls = Array.isArray(event.data.urls) ? event.data.urls : [];
+  const sameOriginUrls = urls.filter((url) => {
+    try {
+      return new URL(url, self.location.origin).origin === self.location.origin;
+    } catch {
+      return false;
+    }
+  });
+  event.waitUntil(
+    cacheUrls(sameOriginUrls).then(() => {
+      event.ports[0]?.postMessage({ type: 'APP_SHELL_ASSETS_CACHED' });
+    }),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET' || request.cache === 'no-store') return;
+
+  const url = new URL(request.url);
+  if (
+    url.origin !== self.location.origin ||
+    url.pathname === '/service-worker.js'
+  ) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigation(request));
+    return;
+  }
+
+  if (['script', 'style', 'font', 'image'].includes(request.destination)) {
+    event.respondWith(handleStaticAsset(request));
+  }
+});


### PR DESCRIPTION
## What

Close #47

- Added production-only service worker registration for offline delivery.
- Cached the application shell and required same-origin static assets after the first successful visit.
- Added production Playwright coverage for offline create, edit, search, export, clear, and restore flows.
- Documented offline behavior and limitations in `docs/OFFLINE.md`.

## Why

Browser-local persistence alone is not sufficient when the app shell cannot load without a network connection. This change allows the core web experience to reopen after a successful first visit while preserving the local-first, no-account model.

## How

- Registered a small custom service worker from the web layout in production builds only.
- Used network-first navigation to receive fresh content while online, with a cached `/app-shell` fallback when offline.
- Used cache-first handling for same-origin scripts, styles, fonts, and images required by the current application shell.
- Explicitly excluded non-GET and `no-store` requests.
- Kept IndexedDB, backup files, form state, and all user-owned archive data outside the service-worker cache.
- Updated E2E execution to run against a production Next.js server rather than the development server.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test` 29 tests passed
- `npm run build --prefix web`
- `npm run test:e2e` 3 Playwright tests passed

The offline E2E test verifies a production build can:

1. Load once online and activate the service worker.
2. Reload offline.
3. Create, edit, and search local data.
4. Export a backup, clear IndexedDB, and restore the backup while offline.

Manual validation must use a production build on HTTPS, `localhost`, or `127.0.0.1`; service workers are intentionally disabled in `next dev`.

## Data impact

No archive schema, migration, backup format, synchronization, or persistence behavior changes.

The service worker caches only delivery assets. It never caches or modifies IndexedDB records, archive snapshots, backup files, or user input.

If offline caching is unavailable, incomplete, or the app has not been visited successfully before, the app continues to behave as a normal online application and may not open offline. Existing user data is never deleted, replaced, or cached by the service worker.

## Checklist

- [x] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
- [x] Tests added or updated for behavior changes
- [x] Documentation updated if public behavior changed
- [x] Accessibility considered for UI/interaction changes
- [x] No unrelated refactors bundled into this PR